### PR TITLE
Improvements/bugfixes for Maze, Secret Collect

### DIFF
--- a/project/src/main/card-control.gd
+++ b/project/src/main/card-control.gd
@@ -175,6 +175,8 @@ func _refresh_card_face(card_sprite: Sprite, card_type: int, card_details: Strin
 				var arrow_indexes: Array = ARROW_INDEXES_BY_DETAILS[card_details]
 				arrow_index = arrow_indexes[randi() % arrow_indexes.size()]
 			else:
+				# We never want random arrows in a level. If this is happening, something is wrong.
+				push_warning("Unrecognized arrow: %s" % [card_details])
 				arrow_index = randi() % ARROW_COUNT
 			card_sprite.wiggle_frames = [2 * arrow_index + 0, 2 * arrow_index + 1]
 		CardType.FISH:

--- a/project/src/main/intermission-panel.gd
+++ b/project/src/main/intermission-panel.gd
@@ -165,6 +165,12 @@ func _sort_by_distance_from_hand(a: Vector2, b: Vector2) -> bool:
 
 
 func _on_SharkSpawnTimer_timeout() -> void:
+	if not visible:
+		# After finishing the game, sometimes an invisible 'ghost frog' keeps chasing the cursor. It's rare, but my
+		# guess is it has to do with a race condition where this timer is triggered when the scene is invisible. I'm
+		# adding the same check here in case it happens with sharks too.
+		return
+	
 	var shark_delay_index := sharks.size() - 1
 	if shark_delay_index < SHARK_DELAYS.size() and hand.biteable_fingers >= 1:
 		_spawn_shark()
@@ -172,6 +178,12 @@ func _on_SharkSpawnTimer_timeout() -> void:
 
 
 func _on_FrogSpawnTimer_timeout() -> void:
+	if not visible:
+		# After finishing the game, sometimes an invisible 'ghost' frog keeps chasing the cursor.
+		# It's rare, but my guess is it has to do with a race condition where this timer is triggered when the scene
+		# is invisible.
+		return
+	
 	var frog_delay_index := frogs.size() - 1
 	if frog_delay_index < FROG_DELAYS.size() and frogs.size() < max_frogs:
 		_spawn_frog()

--- a/project/src/main/maze-level-rules.gd
+++ b/project/src/main/maze-level-rules.gd
@@ -137,9 +137,10 @@ func add_cards() -> void:
 	var start_directions := ["n", "w", "s", "e"]
 	_remaining_path_cells = random.randi_range(0, _average_path_cells + 1)
 	if _max_loose_end_count > 1 and randf() < 1.0 / _average_path_cells:
-		start_directions = ["ne", "nw", "se", "sw", "ns", "we"]
+		start_directions = ["ne", "nw", "se", "sw", "ns", "ew"]
 		_remaining_path_cells = random.randi_range(_average_path_cells - 1, _average_path_cells + 1)
-	_arrowify_card(start_card, Utils.rand_value(start_directions))
+	var start_direction: String = Utils.rand_value(start_directions)
+	_arrowify_card(start_card, start_direction)
 	start_card.show_front()
 	_unflipped_card_positions.erase(_start_position)
 	

--- a/project/src/main/secret-collect-level-rules.gd
+++ b/project/src/main/secret-collect-level-rules.gd
@@ -287,17 +287,15 @@ func _on_LevelCards_before_shark_found() -> void:
 	var frog_card := level_cards.get_card(frog_position)
 	frog_card.show_front()
 	
-	if not _arrow_placed():
-		for adjacent_card in _adjacent_cards(frog_card):
-			if not adjacent_card.is_front_shown() and adjacent_card.card_front_type == CardControl.CardType.FISH:
-				var arrow_details := ""
-				match frog_position - level_cards.get_cell_pos(adjacent_card):
-					Vector2.UP: arrow_details = "n"
-					Vector2.DOWN: arrow_details = "s"
-					Vector2.LEFT: arrow_details = "w"
-					Vector2.RIGHT: arrow_details = "e"
-				if arrow_details:
-					adjacent_card.card_front_type = CardControl.CardType.ARROW
-					adjacent_card.card_front_details = arrow_details
-					adjacent_card.show_front()
-					break
+	for adjacent_card in _adjacent_cards(frog_card):
+		if not adjacent_card.is_front_shown() and adjacent_card.card_front_type == CardControl.CardType.FISH:
+			var arrow_details := ""
+			match frog_position - level_cards.get_cell_pos(adjacent_card):
+				Vector2.UP: arrow_details = "n"
+				Vector2.DOWN: arrow_details = "s"
+				Vector2.LEFT: arrow_details = "w"
+				Vector2.RIGHT: arrow_details = "e"
+			if arrow_details:
+				adjacent_card.card_front_type = CardControl.CardType.ARROW
+				adjacent_card.card_front_details = arrow_details
+				adjacent_card.show_front()


### PR DESCRIPTION
Fixed bug where maze could start with a shark. This is because instead
of trying to render a 'ew' arrow, it would try to render a 'we' arrow
which doesn't exist, resulting in a random arrow. I've added a warning
just in case this happens again.

Secret collect now shows all four arrows upon failing. This might help
players understand to look for those arrows, and that they don't have to
click all four surrounding squares to try and find the arrow.