### PR TITLE
Eliminated triple-quote 'comments'

### DIFF
--- a/project/src/main/background.gd
+++ b/project/src/main/background.gd
@@ -84,11 +84,9 @@ func _on_ChangeTween_tween_completed(object: Object, key: NodePath) -> void:
 		object.visible = false
 
 
-"""
-Returns a transparent version of the specified color.
-
-Tweening from forest green to 'Color.transparent' results in some strange in-between frames which are grey or white.
-It's better to tween to a transparent forest green.
-"""
+## Returns a transparent version of the specified color.
+##
+## Tweening from forest green to 'Color.transparent' results in some strange in-between frames which are grey or white.
+## It's better to tween to a transparent forest green.
 static func to_transparent(color: Color, alpha := 0.0) -> Color:
 	return Color(color.r, color.g, color.b, alpha)

--- a/project/src/main/finger-sprite.gd
+++ b/project/src/main/finger-sprite.gd
@@ -31,10 +31,8 @@ func _ready() -> void:
 	$AnimationPlayer.play("reset")
 
 
-"""
-Parameters:
-	'finger_index': 2 = pinky finger, 1 = naughty finger, 0 = pointer finger
-"""
+## Parameters:
+## 	'finger_index': 2 = pinky finger, 1 = naughty finger, 0 = pointer finger
 func bite(finger_index: int) -> void:
 	wiggle_frames = WIGGLE_FRAMES_BY_BITTEN_FINGER[finger_index]
 	_wiggle_timer.assign_wiggle_frame()
@@ -49,10 +47,8 @@ func bite(finger_index: int) -> void:
 	$CartoonBiteSfx.play()
 
 
-"""
-Parameters:
-	'finger_index': 0 = right frog, 2 = left frog, 1 = middle frog
-"""
+## Parameters:
+## 	'finger_index': 0 = right frog, 2 = left frog, 1 = middle frog
 func hug(finger_index: int) -> void:
 	wiggle_frames = WIGGLE_FRAMES_BY_HUGGED_FINGER[finger_index]
 	_wiggle_timer.assign_wiggle_frame()

--- a/project/src/main/froggo-level-rules.gd
+++ b/project/src/main/froggo-level-rules.gd
@@ -187,9 +187,7 @@ func add_cards() -> void:
 		_add_word(words[i], word_cell_pos)
 
 
-"""
-Replaces lower-case (hidden) letters with upper-case (revealed) letters.
-"""
+## Replaces lower-case (hidden) letters with upper-case (revealed) letters.
 func _reveal_letters(word: String, count: int) -> String:
 	var card_word := word.split("/")[0]
 	var english_word := word.split("/")[1]
@@ -223,16 +221,12 @@ func _reveal_letters(word: String, count: int) -> String:
 	return "%s/%s" % [card_word, english_word]
 
 
-"""
-Replaces lower-case letters with frogs. At least one frog per word.
-"""
+## Replaces lower-case letters with frogs. At least one frog per word.
 func _frogify_letters(word: String, chance: float) -> String:
 	return _replace_letters(word, "+", chance)
 
 
-"""
-Replaces lower-case letters with sharks. At least one shark per word.
-"""
+## Replaces lower-case letters with sharks. At least one shark per word.
 func _sharkify_letters(word: String, chance: float) -> String:
 	return _replace_letters(word, "-", chance)
 
@@ -254,9 +248,7 @@ func _replace_letters(word: String, replacement: String, chance: float) -> Strin
 	return "%s/%s" % [card_word, english_word]
 
 
-"""
-Replaces words with 'troll words'.
-"""
+## Replaces words with 'troll words'.
 func _trollify_words(words: Array, count: int) -> Array:
 	var troll_word_indexes := range(words.size())
 	troll_word_indexes.shuffle()
@@ -272,9 +264,7 @@ func _trollify_words(words: Array, count: int) -> Array:
 	return words
 
 
-"""
-Replaces a word with a silly word that isn't a frog or a shark.
-"""
+## Replaces a word with a silly word that isn't a frog or a shark.
 func _troll_silly_word() -> Array:
 	return troll_silly_words[randi() % troll_silly_words.size()]
 

--- a/project/src/main/utils.gd
+++ b/project/src/main/utils.gd
@@ -1,8 +1,6 @@
 extends Node
 
-"""
-Returns the scancode for a keypress event, or -1 if the event is not a keypress event.
-"""
+## Returns the scancode for a keypress event, or -1 if the event is not a keypress event.
 static func key_scancode(event: InputEvent) -> int:
 	var scancode := -1
 	if event is InputEventKey and event.is_pressed() and not event.is_echo():
@@ -10,8 +8,6 @@ static func key_scancode(event: InputEvent) -> int:
 	return scancode
 
 
-"""
-Returns a random value from the specified array.
-"""
+## Returns a random value from the specified array.
 static func rand_value(values: Array):
 	return values[randi() % values.size()]

--- a/project/src/main/wiggle-timer.gd
+++ b/project/src/main/wiggle-timer.gd
@@ -17,11 +17,9 @@ func reset_wiggle() -> void:
 	start(rand_range(MIN_WIGGLE_TIME, MAX_WIGGLE_TIME))
 
 
-"""
-Updates the sprite's frame to the next 'wiggle frame'.
-
-Defaults to '0' if the current frame isn't a wiggle frame.
-"""
+## Updates the sprite's frame to the next 'wiggle frame'.
+##
+## Defaults to '0' if the current frame isn't a wiggle frame.
 func assign_wiggle_frame() -> void:
 	var wiggle_index:int = (_sprite.wiggle_frames.find(_sprite.frame) + 1) % _sprite.wiggle_frames.size()
 	_sprite.frame = _sprite.wiggle_frames[wiggle_index]


### PR DESCRIPTION
Godot does not support multiline comments, but triple quotes were used as a kludge. I don't like using this kludge anymore.