### PR TITLE
Mission strings. Block progression.

### DIFF
--- a/project/src/demo/level-rules-demo.gd
+++ b/project/src/demo/level-rules-demo.gd
@@ -6,7 +6,7 @@ export (PackedScene) var LevelRulesScene: PackedScene
 
 func _ready() -> void:
 	randomize()
-	_gameplay_panel.game_difficulty = GameplayPanel.GameDifficulty.HARD
+	_gameplay_panel.mission_string = "1-1"
 
 
 func _input(event: InputEvent) -> void:

--- a/project/src/main/MainMenuPanel.tscn
+++ b/project/src/main/MainMenuPanel.tscn
@@ -20,7 +20,7 @@
 [ext_resource path="res://src/main/ui/menu/TutorialButtons.tscn" type="PackedScene" id=19]
 [ext_resource path="res://src/main/ui/menu/level-button-holder.gd" type="Script" id=20]
 
-[node name="MainMenuPanel" type="Panel"]
+[node name="MainMenuPanel" type="Panel" groups=["main_menu_panels"]]
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 50.0

--- a/project/src/main/gameplay-panel.gd
+++ b/project/src/main/gameplay-panel.gd
@@ -1,18 +1,15 @@
 class_name GameplayPanel
 extends Panel
 
-enum GameDifficulty {
-	EASY,
-	MEDIUM,
-	HARD,
-}
-
 signal before_shark_found(card)
 signal shark_found(card)
 signal before_frog_found(card)
 signal frog_found(card)
 
-var game_difficulty: int = GameDifficulty.EASY setget set_game_difficulty
+# a string like '2-3' for the current set of levels, like Super Mario Bros. '1-1' is the first set.
+var mission_string := "1-1" setget set_mission_string
+
+# difficulty ranging 0-8 for the current puzzle. 0 == very easy, 8 == very hard
 var player_puzzle_difficulty := 0
 var player_streak := 0
 var _level_rules: LevelRules
@@ -35,12 +32,12 @@ onready var level_rules_scenes := [
 
 func _ready() -> void:
 	level_rules_scenes.shuffle()
-	_refresh_game_difficulty()
+	_refresh_mission_string()
 
 
-func set_game_difficulty(new_game_difficulty: int) -> void:
-	game_difficulty = new_game_difficulty
-	_refresh_game_difficulty()
+func set_mission_string(new_mission_string: String) -> void:
+	mission_string = new_mission_string
+	_refresh_mission_string()
 
 
 func show_puzzle() -> void:
@@ -67,29 +64,33 @@ func reset() -> void:
 	_level_cards.reset()
 
 
-func restart(new_game_difficulty: int) -> void:
-	set_game_difficulty(new_game_difficulty)
+func restart(new_mission_string: String) -> void:
+	set_mission_string(new_mission_string)
 	player_puzzle_difficulty = _start_difficulty
 	player_streak = 0
 
 
-func _refresh_game_difficulty() -> void:
+func _refresh_mission_string() -> void:
 	_max_puzzle_difficulty = 8
 	_shark_difficulty_decrease = 2
 	
-	match game_difficulty:
-		GameDifficulty.EASY:
+	match mission_string:
+		"1-1", "2-1", "3-1":
 			_start_difficulty = 0
 			_max_puzzle_difficulty = 4
 			_shark_difficulty_decrease = 4
-		GameDifficulty.MEDIUM:
+		"1-2", "2-2", "3-2":
 			_start_difficulty = 2
 			_max_puzzle_difficulty = 8
 			_shark_difficulty_decrease = 3
-		GameDifficulty.HARD:
+		"1-3", "2-3", "3-3":
 			_start_difficulty = 4
 			_max_puzzle_difficulty = 8
 			_shark_difficulty_decrease = 2
+		_:
+			_start_difficulty = 0
+			_max_puzzle_difficulty = 4
+			_shark_difficulty_decrease = 4
 
 
 func _on_LevelCards_frog_found(card: CardControl) -> void:

--- a/project/src/main/intermission-panel.gd
+++ b/project/src/main/intermission-panel.gd
@@ -14,20 +14,66 @@ const FROG_DELAYS := [
 	1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
 ]
 
-var card_positions_by_difficulty := {
-	GameplayPanel.GameDifficulty.EASY:
+const DEFAULT_CARD_POSITIONS := [
+	Vector2(0, 2), Vector2(1, 2), Vector2(2, 2),
+	Vector2(0.5, 1), Vector2(1.5, 1),
+	Vector2(1, 0),
+]
+
+var card_positions_by_mission_string := {
+	"1-1":
 		[
 			Vector2(0, 2), Vector2(1, 2), Vector2(2, 2),
 			Vector2(0.5, 1), Vector2(1.5, 1),
 			Vector2(1, 0),
 		],
-	GameplayPanel.GameDifficulty.MEDIUM:
+	"1-2":
 		[
 			Vector2(1, 2), Vector2(2, 2), Vector2(3, 2),
 			Vector2(3.5, 1), Vector2(2.5, 1), Vector2(1.5, 1), Vector2(0.5, 1),
 			Vector2(0, 0), Vector2(4, 0), Vector2(2, 0),
 		],
-	GameplayPanel.GameDifficulty.HARD:
+	"1-3":
+		[
+			Vector2(2.5, 2.0), Vector2(2.0, 3.0), Vector2(1.5, 2.0), Vector2(1.0, 3.0),
+			Vector2(0.5, 2.0), Vector2(0.0, 1.0), Vector2(0.5, 0.0), Vector2(1.5, 0.0),
+			Vector2(2.0, 1.0), Vector2(3.0, 1.0), Vector2(3.5, 0.0), Vector2(4.5, 0.0),
+			Vector2(5.0, 1.0), Vector2(4.5, 2.0), Vector2(4.0, 3.0), Vector2(3.5, 2.0),
+			Vector2(3.0, 3.0),
+		],
+	"2-1":
+		[
+			Vector2(0, 2), Vector2(1, 2), Vector2(2, 2),
+			Vector2(0.5, 1), Vector2(1.5, 1),
+			Vector2(1, 0),
+		],
+	"2-2":
+		[
+			Vector2(1, 2), Vector2(2, 2), Vector2(3, 2),
+			Vector2(3.5, 1), Vector2(2.5, 1), Vector2(1.5, 1), Vector2(0.5, 1),
+			Vector2(0, 0), Vector2(4, 0), Vector2(2, 0),
+		],
+	"2-3":
+		[
+			Vector2(2.5, 2.0), Vector2(2.0, 3.0), Vector2(1.5, 2.0), Vector2(1.0, 3.0),
+			Vector2(0.5, 2.0), Vector2(0.0, 1.0), Vector2(0.5, 0.0), Vector2(1.5, 0.0),
+			Vector2(2.0, 1.0), Vector2(3.0, 1.0), Vector2(3.5, 0.0), Vector2(4.5, 0.0),
+			Vector2(5.0, 1.0), Vector2(4.5, 2.0), Vector2(4.0, 3.0), Vector2(3.5, 2.0),
+			Vector2(3.0, 3.0),
+		],
+	"3-1":
+		[
+			Vector2(0, 2), Vector2(1, 2), Vector2(2, 2),
+			Vector2(0.5, 1), Vector2(1.5, 1),
+			Vector2(1, 0),
+		],
+	"3-2":
+		[
+			Vector2(1, 2), Vector2(2, 2), Vector2(3, 2),
+			Vector2(3.5, 1), Vector2(2.5, 1), Vector2(1.5, 1), Vector2(0.5, 1),
+			Vector2(0, 0), Vector2(4, 0), Vector2(2, 0),
+		],
+	"3-3":
 		[
 			Vector2(2.5, 2.0), Vector2(2.0, 3.0), Vector2(1.5, 2.0), Vector2(1.0, 3.0),
 			Vector2(0.5, 2.0), Vector2(0.0, 1.0), Vector2(0.5, 0.0), Vector2(1.5, 0.0),
@@ -58,11 +104,11 @@ func is_full() -> bool:
 	return next_card_index >= _intermission_cards.get_cards().size()
 
 
-func restart(game_difficulty: int) -> void:
+func restart(mission_string: String) -> void:
 	next_card_index = 0
 	cards.clear()
 	_intermission_cards.reset()
-	var card_positions: Array = card_positions_by_difficulty[game_difficulty]
+	var card_positions: Array = card_positions_by_mission_string.get(mission_string, DEFAULT_CARD_POSITIONS)
 	for i in range(card_positions.size()):
 		var card := _intermission_cards.create_card()
 		_intermission_cards.add_card(card, card_positions[i])

--- a/project/src/main/level-buttons.gd
+++ b/project/src/main/level-buttons.gd
@@ -4,6 +4,16 @@ signal prev_world_pressed
 signal next_world_pressed
 signal level_pressed(level_index)
 
+onready var next_button: Node = $Next
+
+func _ready() -> void:
+	var main_menu_panels: Array = get_tree().get_nodes_in_group("main_menu_panels")
+	if main_menu_panels.size() == 1:
+		main_menu_panels[0].connect("menu_shown", self, "_on_MainMenuPanel_menu_shown")
+	else:
+		push_warning("Unexpected main menu panel count: %s" % [main_menu_panels.size()])
+
+
 func _on_Prev_pressed() -> void:
 	emit_signal("prev_world_pressed")
 
@@ -14,3 +24,13 @@ func _on_Next_pressed() -> void:
 
 func _on_Level_pressed(level_index: int) -> void:
 	emit_signal("level_pressed", level_index)
+
+
+func _on_MainMenuPanel_menu_shown() -> void:
+	var world_index := get_index()
+	var boss_mission := "%s-%s" % [world_index + 1, 3]
+	if PlayerData.get_mission_cleared(boss_mission) != PlayerData.MissionResult.NONE \
+			and get_index() < get_parent().get_child_count() - 1:
+		next_button.visible = true
+	else:
+		next_button.visible = false

--- a/project/src/main/main-menu-panel.gd
+++ b/project/src/main/main-menu-panel.gd
@@ -1,23 +1,12 @@
 class_name MainMenuPanel
 extends Panel
 
-signal start_pressed(difficulty)
+signal start_pressed(mission_string)
 signal before_frog_found(card)
 signal frog_found(card)
 signal before_shark_found(card)
 signal shark_found(card)
-
-const DIFFICULTY_BY_WORLD_STRING := {
-	"0-0": GameplayPanel.GameDifficulty.EASY,
-	"0-1": GameplayPanel.GameDifficulty.MEDIUM,
-	"0-2": GameplayPanel.GameDifficulty.HARD,
-	"1-0": GameplayPanel.GameDifficulty.EASY,
-	"1-1": GameplayPanel.GameDifficulty.MEDIUM,
-	"1-2": GameplayPanel.GameDifficulty.HARD,
-	"2-0": GameplayPanel.GameDifficulty.EASY,
-	"2-1": GameplayPanel.GameDifficulty.MEDIUM,
-	"2-2": GameplayPanel.GameDifficulty.HARD,
-}
+signal menu_shown
 
 onready var _game_state := $TitleGameState
 onready var _level_button_holder := $LevelButtonHolder
@@ -47,6 +36,8 @@ func show_menu() -> void:
 	
 	$Card1O.card_front_type = CardControl.CardType.SHARK if randf() < 0.15 else CardControl.CardType.FROG
 	$Card2I.card_front_type = CardControl.CardType.SHARK if randf() < 0.15 else CardControl.CardType.FROG
+	
+	emit_signal("menu_shown")
 
 
 func _on_CardControl_before_frog_found(card: CardControl) -> void:
@@ -66,6 +57,5 @@ func _on_CardControl_shark_found(card: CardControl) -> void:
 
 
 func _on_LevelButtons_level_pressed(level_index: int) -> void:
-	var world_string := "%s-%s" % [PlayerData.world_index, level_index]
-	var difficulty: int = DIFFICULTY_BY_WORLD_STRING.get(world_string, GameplayPanel.GameDifficulty.EASY)
-	emit_signal("start_pressed", difficulty)
+	var mission_string := "%s-%s" % [PlayerData.world_index + 1, level_index + 1]
+	emit_signal("start_pressed", mission_string)

--- a/project/src/main/menu-state.gd
+++ b/project/src/main/menu-state.gd
@@ -48,15 +48,14 @@ func _show_intermission_panel(card: CardControl) -> void:
 			yield(get_tree().create_timer(3.0), "timeout")
 			if PlayerData.music_preference != PlayerData.MusicPreference.OFF:
 				_music_player.play_ending_song()
-			if PlayerData.hardest_difficulty_cleared < _gameplay_panel.game_difficulty:
-				PlayerData.hardest_difficulty_cleared = _gameplay_panel.game_difficulty
-				PlayerData.save_player_data()
-			match _gameplay_panel.game_difficulty:
-				GameplayPanel.GameDifficulty.HARD:
-					_intermission_panel.start_frog_hug_timer(3, 30)
-				GameplayPanel.GameDifficulty.MEDIUM:
+			match _gameplay_panel.mission_string:
+				"1-1", "2-1", "3-1":
+					_intermission_panel.start_frog_hug_timer(1, 5)
+				"1-2", "2-2", "3-2":
 					_intermission_panel.start_frog_hug_timer(2, 12)
-				GameplayPanel.GameDifficulty.EASY, _:
+				"1-3", "2-3", "3-3":
+					_intermission_panel.start_frog_hug_timer(3, 30)
+				_:
 					_intermission_panel.start_frog_hug_timer(1, 5)
 		else:
 			yield(get_tree().create_timer(3.0), "timeout")
@@ -68,12 +67,14 @@ func _end_intermission() -> void:
 		# we lose
 		_hide_panels()
 		_intermission_panel.reset() # free any sharks/frogs
+		PlayerData.set_mission_cleared(_gameplay_panel.mission_string, PlayerData.MissionResult.SHARK)
 		PlayerData.save_player_data()
 		_main_menu_panel.show_menu()
 	elif _intermission_panel.is_full():
 		# we win
 		_hide_panels()
 		_intermission_panel.reset() # free any sharks/frogs
+		PlayerData.set_mission_cleared(_gameplay_panel.mission_string, PlayerData.MissionResult.FROG)
 		PlayerData.save_player_data()
 		_main_menu_panel.show_menu()
 	else:
@@ -82,7 +83,7 @@ func _end_intermission() -> void:
 		_gameplay_panel.show_puzzle()
 
 
-func _on_MainMenuPanel_start_pressed(difficulty: int) -> void:
+func _on_MainMenuPanel_start_pressed(mission_string: String) -> void:
 	# save, in case the user changed their music preference
 	PlayerData.save_player_data()
 	
@@ -93,8 +94,8 @@ func _on_MainMenuPanel_start_pressed(difficulty: int) -> void:
 	
 	_hide_panels()
 	_hand.reset()
-	_intermission_panel.restart(difficulty)
-	_gameplay_panel.restart(difficulty)
+	_intermission_panel.restart(mission_string)
+	_gameplay_panel.restart(mission_string)
 	_gameplay_panel.show_puzzle()
 
 

--- a/project/src/main/ui/menu/TutorialButtons.tscn
+++ b/project/src/main/ui/menu/TutorialButtons.tscn
@@ -52,7 +52,6 @@ icon_texture = ExtResource( 5 )
 icon_index = 5
 
 [node name="Level2" parent="." instance=ExtResource( 4 )]
-visible = false
 margin_left = 422.0
 margin_right = 502.0
 __meta__ = {
@@ -62,7 +61,6 @@ icon_texture = ExtResource( 5 )
 icon_index = 6
 
 [node name="Level3" parent="." instance=ExtResource( 4 )]
-visible = false
 margin_left = 502.0
 margin_right = 582.0
 __meta__ = {

--- a/project/src/main/ui/menu/World1Buttons.tscn
+++ b/project/src/main/ui/menu/World1Buttons.tscn
@@ -60,7 +60,6 @@ icon_texture = ExtResource( 5 )
 icon_index = 6
 
 [node name="Level3" parent="." instance=ExtResource( 1 )]
-visible = false
 margin_left = 502.0
 margin_right = 582.0
 __meta__ = {


### PR DESCRIPTION
Replaced 'difficulty' with 'mission string'. The first level corresponds to '1-1', and the last level currently corresponds to '3-3' but will eventually be something like '10-3'. Instead of storing the furthest difficulty the player's cleared, we now store all of the mission string outcomes.

The player cannot progress to later worlds until they finish the third level in a world. It is okay if they find all sharks and no frogs, they just have to play it and reach an ending.

Level buttons are now all visible -- since the player has to clear the third level in a world to progress, progression was permanently blocked if those buttons weren't available