### PR TITLE
Avoid int(rand_range()). Public constants.

### DIFF
--- a/project/src/main/froggo-level-rules.gd
+++ b/project/src/main/froggo-level-rules.gd
@@ -201,7 +201,7 @@ func add_cards() -> void:
 	
 	words.shuffle()
 	for i in range(words.size()):
-		var word_cell_pos := Vector2(int(rand_range(0, 3)), i)
+		var word_cell_pos := Vector2(Utils.randi_range(0, 2), i)
 		
 		# shift short words to the right to keep them centered
 		word_cell_pos.x += int(3 - words[i].length() / 2)

--- a/project/src/main/gameplay-panel.gd
+++ b/project/src/main/gameplay-panel.gd
@@ -3,7 +3,7 @@ extends Panel
 ## Panel which shows the level the player is currently playing.
 
 ## List of level IDs to show if the mission is not found
-const _DEFAULT_LEVEL_IDS := ["froggo", "maze"]
+const DEFAULT_LEVEL_IDS := ["froggo", "maze"]
 
 ## Dictionary of levels for each mission.
 ##
@@ -22,7 +22,7 @@ const _DEFAULT_LEVEL_IDS := ["froggo", "maze"]
 ##
 ## key: (String) mission string
 ## value: (Array, String) level ids with an optional difficulty adjustment. '--' = very easy, '++' = very hard
-const _LEVEL_IDS_BY_MISSION_STRING := {
+const LEVEL_IDS_BY_MISSION_STRING := {
 	"1-1": ["froggo-", "maze-"],
 	"1-2": ["pattern-memory-", "word-find-"],
 	"1-3": ["froggo", "pattern-memory", "maze", "word-find", "secret-collect--"],
@@ -67,7 +67,7 @@ onready var level_rules_scenes_by_id := {
 	"fruit-maze": preload("res://src/main/FruitMazeRules.tscn"),
 }
 
-var level_ids := _DEFAULT_LEVEL_IDS
+var level_ids := DEFAULT_LEVEL_IDS
 
 func _ready() -> void:
 	_refresh_mission_string()
@@ -165,7 +165,7 @@ func _refresh_mission_string() -> void:
 			_max_puzzle_difficulty = 7
 			_shark_difficulty_decrease = 2
 	
-	level_ids = _LEVEL_IDS_BY_MISSION_STRING.get(mission_string, _DEFAULT_LEVEL_IDS)
+	level_ids = LEVEL_IDS_BY_MISSION_STRING.get(mission_string, DEFAULT_LEVEL_IDS)
 
 
 func _on_LevelCards_frog_found(card: CardControl) -> void:

--- a/project/src/main/utils.gd
+++ b/project/src/main/utils.gd
@@ -15,6 +15,11 @@ static func rand_value(values: Array):
 	return values[randi() % values.size()]
 
 
+## Generates a pseudo-random 32-bit signed integer between from and to (inclusive).
+static func randi_range(from: int, to: int) -> int:
+	return randi() % (to + 1 - from) + from
+
+
 ## Updates a card sprite's texture, hframes and vframes.
 ##
 ## This method assumes each frame is 240x240, which is used for the small square frog finder cards.


### PR DESCRIPTION
Replaced int(rand_range()) with homebrew randi_range(). int(rand_range()) can theoretically return an int at the top of the range which could cause bugs.

All constants are public.