### PR TITLE
Hand refactoring: end intermission, comments

### DIFF
--- a/project/src/demo/hand-demo.gd
+++ b/project/src/demo/hand-demo.gd
@@ -5,8 +5,7 @@ extends Node
 ## 	[B]: Bite a finger
 ## 	[3]: Restore all three fingers
 ## 	[=/-]: Change the number of biteable fingers
-## 	[brace right]: Maximize the number of huggable fingers
-## 	[brace left]: Minimize the number of huggable fingers
+## 	[brace keys]: Change the number of hugged fingers
 
 onready var _hand: Hand = $Hand
 
@@ -20,9 +19,9 @@ func _input(event: InputEvent) -> void:
 			_hand.set_biteable_fingers(1)
 			_hand.bite()
 		KEY_MINUS:
-			_hand.set_biteable_fingers(clamp(_hand.biteable_fingers - 1, -1, 3))
+			_hand.set_biteable_fingers(int(clamp(_hand.biteable_fingers - 1, -1, 3)))
 		KEY_EQUAL:
-			_hand.set_biteable_fingers(clamp(_hand.biteable_fingers + 1, -1, 3))
+			_hand.set_biteable_fingers(int(clamp(_hand.biteable_fingers + 1, -1, 3)))
 		KEY_3:
 			_hand.set_fingers(3)
 		KEY_BRACKETRIGHT:

--- a/project/src/main/hand.gd
+++ b/project/src/main/hand.gd
@@ -8,6 +8,12 @@ signal finger_bitten
 signal hug_finished
 
 var fingers := 3 setget set_fingers
+
+## Number of fingers remaining on the player's hand which can be bitten by sharks.
+##
+## If this number is 0 or greater, the player is in a chase and the hand shows the number of fingers remaining.
+##
+## If this number is -1, then the player is in a puzzle or on the main menu and the hand shows an index finger.
 var biteable_fingers := -1 setget set_biteable_fingers
 var huggable_fingers := 0 setget set_huggable_fingers
 var hugged_fingers := 0
@@ -34,6 +40,7 @@ func reset() -> void:
 	biteable_fingers = -1
 	huggable_fingers = 0
 	hugged_fingers = 0
+	_refresh_hand_sprite()
 
 
 func bite() -> void:

--- a/project/src/main/menu-state.gd
+++ b/project/src/main/menu-state.gd
@@ -47,17 +47,7 @@ func _show_intermission_panel(card: CardControl) -> void:
 			# we won!
 			_music_player.fade_out(4.0)
 			yield(get_tree().create_timer(3.0), "timeout")
-			if PlayerData.music_preference != PlayerData.MusicPreference.OFF:
-				_music_player.play_ending_song()
-			match _gameplay_panel.mission_string:
-				"1-1", "2-1", "3-1":
-					_intermission_panel.start_frog_hug_timer(1, 5)
-				"1-2", "2-2", "3-2":
-					_intermission_panel.start_frog_hug_timer(2, 12)
-				"1-3", "2-3", "3-3":
-					_intermission_panel.start_frog_hug_timer(3, 30)
-				_:
-					_intermission_panel.start_frog_hug_timer(1, 5)
+			_play_ending()
 		else:
 			yield(get_tree().create_timer(3.0), "timeout")
 			_end_intermission()
@@ -65,23 +55,43 @@ func _show_intermission_panel(card: CardControl) -> void:
 
 func _end_intermission() -> void:
 	if _hand.fingers == 0:
-		# we lose
+		# we lose; return to the main menu
 		_hide_panels()
+		_hand.reset() # restore any bitten fingers
 		_intermission_panel.reset() # free any sharks/frogs
 		PlayerData.set_mission_cleared(_gameplay_panel.mission_string, PlayerData.MissionResult.SHARK)
 		PlayerData.save_player_data()
 		_main_menu_panel.show_menu()
 	elif _intermission_panel.is_full():
-		# we win
+		# we win; return to the main menu
 		_hide_panels()
+		_hand.reset() # restore any bitten fingers
 		_intermission_panel.reset() # free any sharks/frogs
 		PlayerData.set_mission_cleared(_gameplay_panel.mission_string, PlayerData.MissionResult.FROG)
 		PlayerData.save_player_data()
 		_main_menu_panel.show_menu()
 	else:
+		# restore the hand to an index finger
+		_hand.biteable_fingers = -1
+		
+		# show the next puzzle
 		_hide_panels()
 		_background.change()
 		_gameplay_panel.show_puzzle()
+
+
+func _play_ending() -> void:
+	if PlayerData.music_preference != PlayerData.MusicPreference.OFF:
+		_music_player.play_ending_song()
+	match _gameplay_panel.mission_string:
+		"1-1", "2-1", "3-1":
+			_intermission_panel.start_frog_hug_timer(1, 5)
+		"1-2", "2-2", "3-2":
+			_intermission_panel.start_frog_hug_timer(2, 12)
+		"1-3", "2-3", "3-3":
+			_intermission_panel.start_frog_hug_timer(3, 30)
+		_:
+			_intermission_panel.start_frog_hug_timer(1, 5)
 
 
 func _on_MainMenuPanel_start_pressed(mission_string: String) -> void:
@@ -124,7 +134,6 @@ func _on_GameplayPanel_frog_found(card: CardControl) -> void:
 func _on_Hand_finger_bitten() -> void:
 	if _hand.biteable_fingers == 0:
 		yield(get_tree().create_timer(4.0), "timeout")
-		_hand.biteable_fingers = -1
 		_end_intermission()
 
 


### PR DESCRIPTION
Extracted _end_intermission() method. This method now always restores the hand's biteable fingers to -1, turning the hand back into a pointer.

Improved hand comments. The demo comments were misleading. Added comments describing the rather obscure dual purpose 'biteable fingers' field. Extracted a new 'play_ending' method.