### PR TITLE
Replaced 'yield' statements with timers and signals.

### DIFF
--- a/project/src/main/MainMenu.tscn
+++ b/project/src/main/MainMenu.tscn
@@ -1,12 +1,12 @@
 [gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://src/main/MusicPlayer.tscn" type="PackedScene" id=1]
+[ext_resource path="res://src/main/MenuState.tscn" type="PackedScene" id=2]
 [ext_resource path="res://src/main/MainMenuPanel.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/main/game-state.gd" type="Script" id=5]
 [ext_resource path="res://src/main/gameplay-panel.gd" type="Script" id=6]
 [ext_resource path="res://src/main/level-cards.gd" type="Script" id=13]
 [ext_resource path="res://src/main/IntermissionPanel.tscn" type="PackedScene" id=15]
-[ext_resource path="res://src/main/menu-state.gd" type="Script" id=16]
 [ext_resource path="res://src/main/Hand.tscn" type="PackedScene" id=17]
 [ext_resource path="res://src/main/Background.tscn" type="PackedScene" id=18]
 [ext_resource path="res://src/main/ui/menu/rounded-style-box.tres" type="StyleBox" id=38]
@@ -19,8 +19,7 @@ anchor_bottom = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 
-[node name="MenuState" type="Node" parent="Content"]
-script = ExtResource( 16 )
+[node name="MenuState" parent="Content" instance=ExtResource( 2 )]
 _main_menu_panel_path = NodePath("../MainMenuPanel")
 _gameplay_panel_path = NodePath("../GameplayPanel")
 _intermission_panel_path = NodePath("../IntermissionPanel")
@@ -77,11 +76,6 @@ margin_bottom = 129.947
 
 [node name="MusicPlayer" parent="." instance=ExtResource( 1 )]
 
-[connection signal="before_frog_found" from="Content/MainMenuPanel" to="Content/MenuState" method="_on_MainMenuPanel_before_frog_found"]
-[connection signal="before_shark_found" from="Content/MainMenuPanel" to="Content/MenuState" method="_on_MainMenuPanel_before_shark_found"]
-[connection signal="frog_found" from="Content/MainMenuPanel" to="Content/MenuState" method="_on_MainMenuPanel_frog_found"]
-[connection signal="shark_found" from="Content/MainMenuPanel" to="Content/MenuState" method="_on_MainMenuPanel_shark_found"]
-[connection signal="start_pressed" from="Content/MainMenuPanel" to="Content/MenuState" method="_on_MainMenuPanel_start_pressed"]
 [connection signal="before_frog_found" from="Content/GameplayPanel" to="Content/MenuState" method="_on_GameplayPanel_before_frog_found"]
 [connection signal="before_shark_found" from="Content/GameplayPanel" to="Content/MenuState" method="_on_GameplayPanel_before_shark_found"]
 [connection signal="frog_found" from="Content/GameplayPanel" to="Content/MenuState" method="_on_GameplayPanel_frog_found"]
@@ -91,4 +85,9 @@ margin_bottom = 129.947
 [connection signal="frog_found" from="Content/GameplayPanel/LevelCards" to="Content/GameplayPanel" method="_on_LevelCards_frog_found"]
 [connection signal="shark_found" from="Content/GameplayPanel/LevelCards" to="Content/GameplayPanel" method="_on_LevelCards_shark_found"]
 [connection signal="bye_pressed" from="Content/IntermissionPanel" to="Content/MenuState" method="_on_IntermissionPanel_bye_pressed"]
+[connection signal="before_frog_found" from="Content/MainMenuPanel" to="Content/MenuState" method="_on_MainMenuPanel_before_frog_found"]
+[connection signal="before_shark_found" from="Content/MainMenuPanel" to="Content/MenuState" method="_on_MainMenuPanel_before_shark_found"]
+[connection signal="frog_found" from="Content/MainMenuPanel" to="Content/MenuState" method="_on_MainMenuPanel_frog_found"]
+[connection signal="shark_found" from="Content/MainMenuPanel" to="Content/MenuState" method="_on_MainMenuPanel_shark_found"]
+[connection signal="start_pressed" from="Content/MainMenuPanel" to="Content/MenuState" method="_on_MainMenuPanel_start_pressed"]
 [connection signal="finger_bitten" from="Hand" to="Content/MenuState" method="_on_Hand_finger_bitten"]

--- a/project/src/main/MenuState.tscn
+++ b/project/src/main/MenuState.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://src/main/menu-state.gd" type="Script" id=1]
+
+[node name="MenuState" type="Node"]
+script = ExtResource( 1 )
+
+[node name="Timers" type="Node" parent="."]


### PR DESCRIPTION
This avoids potential complications when levels are interrupted or paused, because these timers can be easily cleaned up. Yield statements can't really be interrupted, and anonymous timers can't really be cleaned up.