### PR TITLE
Split out 'CreatureBehavior' from 'RunningFrog'

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -24,6 +24,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/ui/menu/clickable-icon.gd"
 }, {
+"base": "Node",
+"class": "CreatureBehavior",
+"language": "GDScript",
+"path": "res://src/main/creature-behavior.gd"
+}, {
 "base": "Reference",
 "class": "FileUtils",
 "language": "GDScript",
@@ -113,6 +118,7 @@ _global_script_class_icons={
 "Background": "",
 "CardControl": "",
 "ClickableIcon": "",
+"CreatureBehavior": "",
 "FileUtils": "",
 "GameState": "",
 "GameplayPanel": "",
@@ -141,8 +147,8 @@ config/version="1.05"
 
 [autoload]
 
-PlayerData="*res://src/main/player-data.gd"
 CardArrangements="*res://src/main/card-arrangements.gd"
+PlayerData="*res://src/main/player-data.gd"
 
 [debug]
 

--- a/project/src/main/RunningFrog.tscn
+++ b/project/src/main/RunningFrog.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://src/main/running-frog.gd" type="Script" id=1]
 [ext_resource path="res://assets/main/frog-run-sheet.png" type="Texture" id=2]
+[ext_resource path="res://src/main/frog-chase-behavior.gd" type="Script" id=3]
 
 [sub_resource type="Animation" id=1]
 resource_name = "hug"
@@ -68,23 +69,25 @@ hframes = 5
 frame = 2
 script = ExtResource( 1 )
 
+[node name="ChaseBehavior" type="Node" parent="."]
+script = ExtResource( 3 )
+
+[node name="ChaseTimer" type="Timer" parent="ChaseBehavior"]
+wait_time = 8.0
+one_shot = true
+
+[node name="PanicTimer" type="Timer" parent="ChaseBehavior"]
+wait_time = 1.5
+one_shot = true
+
+[node name="ThinkTimer" type="Timer" parent="ChaseBehavior"]
+wait_time = 0.1
+
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 autoplay = "run"
 anims/hug = SubResource( 1 )
 anims/run = SubResource( 2 )
 
-[node name="ChaseTimer" type="Timer" parent="."]
-wait_time = 8.0
-one_shot = true
-
-[node name="PanicTimer" type="Timer" parent="."]
-wait_time = 1.5
-one_shot = true
-
-[node name="ThinkTimer" type="Timer" parent="."]
-wait_time = 0.1
-autostart = true
-
-[connection signal="timeout" from="ChaseTimer" to="." method="_on_ChaseTimer_timeout"]
-[connection signal="timeout" from="PanicTimer" to="." method="_on_PanicTimer_timeout"]
-[connection signal="timeout" from="ThinkTimer" to="." method="_on_ThinkTimer_timeout"]
+[connection signal="timeout" from="ChaseBehavior/ChaseTimer" to="ChaseBehavior" method="_on_ChaseTimer_timeout"]
+[connection signal="timeout" from="ChaseBehavior/PanicTimer" to="ChaseBehavior" method="_on_PanicTimer_timeout"]
+[connection signal="timeout" from="ChaseBehavior/ThinkTimer" to="ChaseBehavior" method="_on_ThinkTimer_timeout"]

--- a/project/src/main/creature-behavior.gd
+++ b/project/src/main/creature-behavior.gd
@@ -1,0 +1,24 @@
+class_name CreatureBehavior
+extends Node
+## Defines a behavior for a frog or shark.
+##
+## This behavior is something complex like 'chasing after the cursor' or 'doing a dance', and can combine several
+## actions or animations.
+
+## Starts the behavior.
+##
+## Parameters:
+## 	_creature: The RunningFrog or RunningShark which should perform this behavior.
+func start_behavior(_creature: Node) -> void:
+	pass
+
+
+## Stops the behavior.
+##
+## This is called before changing to a new behavior. It should stop any timers and reset any transient data for this
+## behavior.
+##
+## Parameters:
+## 	_creature: The RunningFrog or RunningShark which should stop performing this behavior.
+func stop_behavior(_creature: Node) -> void:
+	pass

--- a/project/src/main/frog-chase-behavior.gd
+++ b/project/src/main/frog-chase-behavior.gd
@@ -1,0 +1,120 @@
+extends CreatureBehavior
+## Defines how a frog chases the player's cursor.
+
+const HUG_DISTANCE := 40.0
+const CHASE_DURATION := 6
+const PANIC_DURATION := 1.2
+const SUPER_PANIC_DURATION := 4.8
+const PINCER_DISTANCE := 150.0
+
+## where the frog has to stand to count as 'catching' the hand
+const HAND_CATCH_OFFSET := Vector2(28, 20)
+
+var friend: Sprite
+var hand: Hand setget set_hand
+
+var _frog: RunningFrog
+var _chase_count := 0
+
+onready var _chase_timer := $ChaseTimer
+onready var _panic_timer := $PanicTimer
+onready var _think_timer := $ThinkTimer
+
+
+func set_hand(new_hand: Hand) -> void:
+	if hand:
+		hand.disconnect("hug_finished", self, "_on_Hand_hug_finished")
+	
+	hand = new_hand
+	
+	if hand:
+		hand.connect("hug_finished", self, "_on_Hand_hug_finished")
+
+
+func start_behavior(new_frog: Node) -> void:
+	_frog = new_frog
+	_think_timer.start(rand_range(0, 0.1))
+	_chase()
+
+
+func stop_behavior(_new_frog: Node) -> void:
+	# disconnect signals
+	_frog = null
+	friend = null
+	set_hand(null)
+	
+	_think_timer.stop()
+	_chase_timer.stop()
+	_panic_timer.stop()
+
+
+func _chase() -> void:
+	_panic_timer.stop()
+	var wait_time := CHASE_DURATION * rand_range(0.8, 1.2)
+	if _chase_count == 0:
+		# the first time we chase, we are more persistent
+		wait_time *= 2
+	_chase_timer.start(wait_time)
+	_chase_count += 1
+
+
+func _panic() -> void:
+	_chase_timer.stop()
+	_panic_timer.start(PANIC_DURATION * rand_range(0.8, 1.2))
+	_frog.velocity = Vector2.RIGHT.rotated(rand_range(0, PI * 2)) * _frog.run_speed
+
+
+func _on_PanicTimer_timeout() -> void:
+	if hand.hugged_fingers >= hand.huggable_fingers and randf() < 0.5:
+		# oh no, we can't hug the hand! continue panicking!
+		_panic_timer.start(rand_range(SUPER_PANIC_DURATION, 5.0))
+		_frog.velocity = Vector2.RIGHT.rotated(rand_range(0, PI * 2)) * _frog.run_speed
+	else:
+		_chase()
+
+
+func _on_ChaseTimer_timeout() -> void:
+	_panic()
+
+
+func _on_Hand_hug_finished() -> void:
+	if not _frog.is_hugging():
+		return
+	
+	_frog.play_animation("run")
+	_think_timer.start()
+	_panic()
+	_frog.soon_position += _frog.velocity.normalized() * 40
+
+
+func _on_ThinkTimer_timeout() -> void:
+	if not hand or hand.huggable_fingers < 1:
+		return
+	
+	var run_target := hand.rect_global_position + HAND_CATCH_OFFSET
+
+	if not _chase_timer.is_stopped():
+		if ((run_target - _frog.global_position).length() < HUG_DISTANCE) and hand.resting:
+			# we're close enough for a hug
+			if hand.hugged_fingers < hand.huggable_fingers:
+				# we caught the hand... hug!
+				_frog.play_animation("hug")
+				_think_timer.stop()
+				_chase_timer.stop()
+				_panic_timer.stop()
+				hand.hug()
+				_frog.velocity = Vector2.ZERO
+			else:
+				# we're too shy. run away!
+				_panic()
+		else:
+			if friend and not friend.is_hugging() and (run_target - _frog.global_position).length() > PINCER_DISTANCE:
+				# our friend will help us; don't run towards the hand, run behind our friend
+				run_target = friend.global_position + (friend.global_position - run_target).normalized() * PINCER_DISTANCE
+				_frog.velocity = (run_target - _frog.global_position).normalized() * _frog.run_speed
+			
+			# we have no friend; run towards the hand
+			_frog.velocity = (run_target - _frog.global_position).normalized() * _frog.run_speed
+	elif not _panic_timer.is_stopped():
+		# if we're panicking, we continue running in our randomly chosen direction
+		pass

--- a/project/src/main/intermission-panel.gd
+++ b/project/src/main/intermission-panel.gd
@@ -27,6 +27,11 @@ const FROG_DELAYS := [
 var cards: Array = []
 var sharks: Array = []
 var frogs: Array = []
+
+# key: (RunningFrog) frog
+# value: (RunningFrog) friend
+var friends_by_frog := {}
+
 var max_frogs := 0
 var next_card_index := 0
 
@@ -82,6 +87,24 @@ func show_intermission_panel() -> void:
 	reset()
 
 
+func start_shark_spawn_timer(biteable_fingers: int = 1) -> void:
+	hand.biteable_fingers = biteable_fingers
+	$SharkSpawnTimer.start()
+	for _finger in range(biteable_fingers):
+		# spawn one shark per finger
+		_spawn_shark()
+
+
+func start_frog_hug_timer(huggable_fingers: int, new_max_frogs: int) -> void:
+	max_frogs = new_max_frogs
+	hand.huggable_fingers = huggable_fingers
+	$FrogSpawnTimer.start()
+	for _finger in range(huggable_fingers):
+		# spawn one frog per finger
+		var frog := _spawn_frog()
+		_chase(frog)
+
+
 func _spawn_shark() -> void:
 	var shark: RunningShark = RunningSharkScene.instance()
 	shark.hand = hand
@@ -106,9 +129,8 @@ func _spawn_shark() -> void:
 	shark.chase()
 
 
-func _spawn_frog() -> void:
+func _spawn_frog() -> RunningFrog:
 	var frog: RunningFrog = RunningFrogScene.instance()
-	frog.hand = hand
 	
 	var viewport_rect_size := get_viewport_rect().size
 	
@@ -120,32 +142,18 @@ func _spawn_frog() -> void:
 	]
 	spawn_points.sort_custom(self, "_sort_by_distance_from_hand")
 	
-	if frogs.size() % 2 == 1:
-		# this frog has a friend
-		frog.friend = frogs[frogs.size() - 1]
-	
 	frog.soon_position = spawn_points[0]
 	$Creatures.add_child(frog)
 	frogs.append(frog)
-	frog.chase()
+	
+	if frogs.size() % 2 == 0:
+		friends_by_frog[frog] = frogs[frogs.size() - 1]
+	return frog
 
 
-func start_shark_spawn_timer(biteable_fingers: int = 1) -> void:
-	hand.biteable_fingers = biteable_fingers
-	$SharkSpawnTimer.start()
-	for _finger in range(biteable_fingers):
-		# spawn one shark per finger
-		_spawn_shark()
-
-
-func start_frog_hug_timer(huggable_fingers: int, new_max_frogs: int) -> void:
-	max_frogs = new_max_frogs
-	hand.huggable_fingers = huggable_fingers
-	$FrogSpawnTimer.start()
-	for _finger in range(huggable_fingers):
-		# spawn one frog per finger
-		_spawn_frog()
-
+func _chase(frog: RunningFrog) -> void:
+	frog.chase(hand, friends_by_frog.get(frog, null))
+	
 
 func _sort_by_distance_from_hand(a: Vector2, b: Vector2) -> bool:
 	return hand.rect_global_position.distance_to(a) > hand.rect_global_position.distance_to(b)
@@ -173,7 +181,8 @@ func _on_FrogSpawnTimer_timeout() -> void:
 	
 	var frog_delay_index := frogs.size() - 1
 	if frog_delay_index < FROG_DELAYS.size() and frogs.size() < max_frogs:
-		_spawn_frog()
+		var frog := _spawn_frog()
+		_chase(frog)
 		$FrogSpawnTimer.start(FROG_DELAYS[frog_delay_index])
 
 

--- a/project/src/main/running-frog.gd
+++ b/project/src/main/running-frog.gd
@@ -1,34 +1,21 @@
 class_name RunningFrog
 extends Sprite
-## Frog which chases the player's cursor.
+## Frog which can perform different activities such as chasing the player's cursor.
 
-const HUG_DISTANCE := 40.0
-const CHASE_DURATION := 6
-const PANIC_DURATION := 1.2
-const SUPER_PANIC_DURATION := 4.8
 const RUN_SPEED := 150.0
-const PINCER_DISTANCE := 150.0
 
-## where the shark has to stand to count as 'catching' the hand
-const HAND_CATCH_OFFSET := Vector2(28, 20)
-
-var hand: Hand
-var friend: Sprite
-var velocity := Vector2.ZERO
-var run_speed := RUN_SPEED
-
+## frogs move in a jerky way. soon_position stores the location where the frog will blink to after a delay
 var soon_position: Vector2 setget set_soon_position
-var old_frame: int
-var chase_count := 0
+
+var run_speed := RUN_SPEED
+var velocity := Vector2.ZERO
 
 onready var _animation_player := $AnimationPlayer
-onready var _chase_timer := $ChaseTimer
-onready var _panic_timer := $PanicTimer
-onready var _think_timer := $ThinkTimer
+onready var _chase_behavior := $ChaseBehavior
+
+onready var behavior: CreatureBehavior
 
 func _ready() -> void:
-	if hand:
-		hand.connect("hug_finished", self, "_on_Hand_hug_finished")
 	run_speed = RUN_SPEED * rand_range(0.8, 1.2)
 	_refresh_run_speed()
 
@@ -40,20 +27,14 @@ func _physics_process(delta: float) -> void:
 	soon_position.y = clamp(soon_position.y, -200, viewport_rect_size.y + 200)
 
 
-func chase() -> void:
-	_panic_timer.stop()
-	var wait_time := CHASE_DURATION * rand_range(0.8, 1.2)
-	if chase_count == 0:
-		# the first time we chase, we are more persistent
-		wait_time *= 2
-	_chase_timer.start(wait_time)
-	chase_count += 1
+func is_hugging() -> bool:
+	return _animation_player.current_animation == "hug"
 
 
-func panic() -> void:
-	_chase_timer.stop()
-	_panic_timer.start(PANIC_DURATION * rand_range(0.8, 1.2))
-	velocity = Vector2.RIGHT.rotated(rand_range(0, PI * 2)) * run_speed
+func chase(hand: Hand, friend: RunningFrog) -> void:
+	_chase_behavior.hand = hand
+	_chase_behavior.friend = friend
+	_start_behavior(_chase_behavior)
 
 
 func move() -> void:
@@ -61,70 +42,19 @@ func move() -> void:
 	position = soon_position
 
 
+func play_animation(name: String) -> void:
+	_animation_player.play(name)
+
+
 func set_soon_position(new_soon_position: Vector2) -> void:
 	soon_position = new_soon_position
 	position = new_soon_position
 
 
-func is_hugging() -> bool:
-	return _animation_player.current_animation == "hug"
+func _start_behavior(new_behavior: CreatureBehavior) -> void:
+	behavior = new_behavior
+	new_behavior.start_behavior(self)
 
 
 func _refresh_run_speed() -> void:
 	_animation_player.playback_speed = run_speed / 150.0
-
-
-func _on_PanicTimer_timeout() -> void:
-	if hand.hugged_fingers >= hand.huggable_fingers and randf() < 0.5:
-		# oh no, we can't hug the hand! continue panicking!
-		_panic_timer.start(rand_range(SUPER_PANIC_DURATION, 5.0))
-		velocity = Vector2.RIGHT.rotated(rand_range(0, PI * 2)) * run_speed
-	else:
-		chase()
-
-
-func _on_ChaseTimer_timeout() -> void:
-	panic()
-
-
-func _on_Hand_hug_finished() -> void:
-	if not is_hugging():
-		return
-	
-	_animation_player.play("run")
-	_think_timer.start()
-	panic()
-	soon_position += velocity.normalized() * 40
-
-
-func _on_ThinkTimer_timeout() -> void:
-	if not hand or hand.huggable_fingers < 1:
-		return
-	
-	var run_target := hand.rect_global_position + HAND_CATCH_OFFSET
-
-	if not _chase_timer.is_stopped():
-		if ((run_target - global_position).length() < HUG_DISTANCE) and hand.resting:
-			# we're close enough for a hug
-			if hand.hugged_fingers < hand.huggable_fingers:
-				# we caught the hand... hug!
-				_animation_player.play("hug")
-				_think_timer.stop()
-				_chase_timer.stop()
-				_panic_timer.stop()
-				hand.hug()
-				velocity = Vector2.ZERO
-			else:
-				# we're too shy. run away!
-				panic()
-		else:
-			if friend and not friend.is_hugging() and (run_target - global_position).length() > PINCER_DISTANCE:
-				# our friend will help us; don't run towards the hand, run behind our friend
-				run_target = friend.global_position + (friend.global_position - run_target).normalized() * PINCER_DISTANCE
-				velocity = (run_target - global_position).normalized() * run_speed
-			
-			# we have no friend; run towards the hand
-			velocity = (run_target - global_position).normalized() * run_speed
-	elif not _panic_timer.is_stopped():
-		# if we're panicking, we continue running in our randomly chosen direction
-		pass

--- a/project/src/main/running-shark.gd
+++ b/project/src/main/running-shark.gd
@@ -19,9 +19,9 @@ var velocity := Vector2.ZERO
 var run_speed := MIN_RUN_SPEED setget set_run_speed
 var agility := 1.0
 
+## sharks move in a jerky way. soon_position stores the location where the frog will blink to after a delay
 var soon_position: Vector2 setget set_soon_position
-var old_frame: int
-var chase_count := 0
+var _chase_count := 0
 
 onready var _animation_player := $AnimationPlayer
 onready var _chase_timer := $ChaseTimer
@@ -42,11 +42,11 @@ func _physics_process(delta: float) -> void:
 func chase() -> void:
 	_panic_timer.stop()
 	var wait_time := CHASE_DURATION * rand_range(0.8, 1.2)
-	if chase_count == 0:
+	if _chase_count == 0:
 		# the first time we chase, we are more persistent
 		wait_time *= 2
 	_chase_timer.start(wait_time)
-	chase_count += 1
+	_chase_count += 1
 
 
 func panic() -> void:


### PR DESCRIPTION
In their current implementation, frogs always chase the cursor but they'll eventually need to do multiple things. I've split out the 'CreatureBehavior' with a single implementation, 'FrogChaseBehavior'. This encapsulates the behavior of chasing the cursor, and other scripts will eventually extend CreatureBehavior with other behaviors such as dancing.

This change only affects frogs for now -- it is still heavily in flux, and sharks only do one thing right now. Once it is more mature or there is a need for it, I will apply the change to sharks.

Removed unused 'old_frame' field.