### PR TITLE
Disable MusicPlayer from playing music during demos.

### DIFF
--- a/project/src/main/menu-state.gd
+++ b/project/src/main/menu-state.gd
@@ -25,6 +25,8 @@ func _ready() -> void:
 	
 	yield(get_tree(), "idle_frame")
 	_main_menu_panel.show_menu()
+	
+	MusicPlayer.play_preferred_song()
 
 
 func _hide_panels() -> void:

--- a/project/src/main/music-player.gd
+++ b/project/src/main/music-player.gd
@@ -64,7 +64,6 @@ func _ready() -> void:
 	random.randomize()
 	PlayerData.connect("music_preference_changed", self, "_on_PlayerData_music_preference_changed")
 	PlayerData.connect("world_index_changed", self, "_on_PlayerData_world_index_changed")
-	play_preferred_song()
 
 
 func play_preferred_song() -> void:


### PR DESCRIPTION
Instead of MusicPlayer playing music on startup, MenuState now plays music on startup. This prevents music from playing during demos.