### PR TITLE
Music api: fade_in, get_playback_position

### DIFF
--- a/project/src/demo/intermission-panel-demo.gd
+++ b/project/src/demo/intermission-panel-demo.gd
@@ -3,6 +3,7 @@ extends Node
 ##
 ## Keys:
 ## 	[F]: Show a frog card.
+## 	[M]: Play some music.
 ## 	[S]: Spawn a shark.
 ## 	[1]: Spawn some frogs, one of which will hug your hand.
 ## 	[2]: Spawn some frogs, two of which will hug your hand.
@@ -26,6 +27,10 @@ func _input(event: InputEvent) -> void:
 			
 			card.show_front()
 			_intermission_panel.add_level_result(card)
+		KEY_M:
+			if PlayerData.music_preference == PlayerData.MusicPreference.OFF:
+				PlayerData.music_preference = PlayerData.MusicPreference.RANDOM
+			MusicPlayer.play_preferred_song()
 		KEY_S:
 			_intermission_panel.start_shark_spawn_timer(3)
 		KEY_1:

--- a/project/src/main/MusicPlayer.tscn
+++ b/project/src/main/MusicPlayer.tscn
@@ -35,10 +35,6 @@ bus = "Music"
 stream = ExtResource( 7 )
 bus = "Music"
 
-[node name="WereGonnaEatYouUp" type="AudioStreamPlayer" parent="."]
-stream = ExtResource( 18 )
-bus = "Music"
-
 [node name="HalfAFrog" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 9 )
 bus = "Music"
@@ -93,6 +89,10 @@ bus = "Music"
 
 [node name="WeAreTheBaddies" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 5 )
+bus = "Music"
+
+[node name="WereGonnaEatYouUp" type="AudioStreamPlayer" parent="."]
+stream = ExtResource( 18 )
 bus = "Music"
 
 [node name="FadeTween" type="Tween" parent="."]

--- a/project/src/main/music-player.gd
+++ b/project/src/main/music-player.gd
@@ -141,6 +141,19 @@ func fade_out(duration := FADE_OUT_DURATION) -> void:
 	_current_song = null
 
 
+## Force the currently playing song to fade in.
+##
+## This can be called immediately after playing a song to ensure it fades in, rather than starting abruptly.
+func fade_in(duration := FADE_OUT_DURATION) -> void:
+	if not _current_song:
+		return
+	
+	_current_song.volume_db = MIN_VOLUME
+	_fade_tween.remove(_current_song, "volume_db")
+	_fade_tween.interpolate_property(_current_song, "volume_db", _current_song.volume_db, MAX_VOLUME, duration)
+	_fade_tween.start()
+
+
 func play_ending_song() -> void:
 	if _position_by_song.get(_ending_song, 0.0) > 80:
 		# more than half way through the ending song; start over
@@ -154,6 +167,13 @@ func is_playing_shark_song() -> bool:
 
 func is_playing_frog_song() -> bool:
 	return _current_song in _frog_songs
+
+
+func get_playback_position() -> float:
+	var result := 0.0
+	if _current_song:
+		result = _current_song.get_playback_position()
+	return result
 
 
 func _on_FadeTween_tween_completed(object: Object, key: NodePath) -> void:


### PR DESCRIPTION
Added fade_in() and get_playback_position() methods to music api. This is useful for synchronizing dances or forcing music to fade in, instead of playing abruptly after a cutscene.

Alphabetized 'WereGonnaEatYouUp' AudioStreamPlayer node.

Added music toggle to IntermissionPanelDemo.