### PR TITLE
Center intermission panel creatures.

### DIFF
--- a/project/src/main/IntermissionPanel.tscn
+++ b/project/src/main/IntermissionPanel.tscn
@@ -50,8 +50,14 @@ wait_time = 8.0
 one_shot = true
 
 [node name="Creatures" type="Control" parent="."]
-anchor_right = 1.0
-anchor_bottom = 1.0
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -462.0
+margin_top = -250.0
+margin_right = 462.0
+margin_bottom = 250.0
 
 [node name="ByeButton" type="Control" parent="."]
 anchor_left = 1.0


### PR DESCRIPTION
Before, resizing the window would cause intermission panel creatures to asymmetrically gravitate towards the top and left corners of the panel. This is an extremely subtle annoyance, but it carries more gravity with the upcoming frog dance where we really want characters to stay centered.