### PR TITLE
Fix creature spawn location.

### DIFF
--- a/project/src/main/intermission-panel.gd
+++ b/project/src/main/intermission-panel.gd
@@ -123,7 +123,7 @@ func _spawn_shark() -> void:
 		# this shark has a friend
 		shark.friend = sharks[sharks.size() - 1]
 	
-	shark.soon_position = spawn_points[0]
+	shark.soon_position = spawn_points[0] - $Creatures.rect_global_position
 	$Creatures.add_child(shark)
 	sharks.append(shark)
 	shark.chase()
@@ -146,7 +146,7 @@ func _spawn_frog() -> RunningFrog:
 		# this frog has a friend
 		friends_by_frog[frog] = frogs[frogs.size() - 1]
 	
-	frog.soon_position = spawn_points[0]
+	frog.soon_position = spawn_points[0] - $Creatures.rect_global_position
 	$Creatures.add_child(frog)
 	frogs.append(frog)
 	return frog


### PR DESCRIPTION
Sharks and frogs were spawning too far down and too the right, sometimes even spawning in a visible location on the left edge. Additionally, their spawn locations were offset even further if the window was enlarged.

Frogs and sharks now spawn in an appropriate location.