### PR TITLE
Fixed bug where dancing frogs could overrun their target.

### DIFF
--- a/project/src/main/RunningFrog.tscn
+++ b/project/src/main/RunningFrog.tscn
@@ -944,15 +944,15 @@ wait_time = 0.1
 [node name="DanceBehavior" type="Node" parent="."]
 script = ExtResource( 4 )
 
+[node name="SyncCheckTimer" type="Timer" parent="DanceBehavior"]
+wait_time = 0.25
+
+[node name="ThinkTimer" type="Timer" parent="DanceBehavior"]
+wait_time = 0.1
+
 [node name="WaitToDanceTimer" type="Timer" parent="DanceBehavior"]
 wait_time = 1.5
 one_shot = true
-
-[node name="RunTimer" type="Timer" parent="DanceBehavior"]
-one_shot = true
-
-[node name="SyncCheckTimer" type="Timer" parent="DanceBehavior"]
-wait_time = 0.25
 
 [node name="DanceAnimations" type="AnimationPlayer" parent="DanceBehavior"]
 anims/RESET = SubResource( 11 )
@@ -1005,6 +1005,6 @@ anims/stand = SubResource( 4 )
 [connection signal="timeout" from="ChaseBehavior/ChaseTimer" to="ChaseBehavior" method="_on_ChaseTimer_timeout"]
 [connection signal="timeout" from="ChaseBehavior/PanicTimer" to="ChaseBehavior" method="_on_PanicTimer_timeout"]
 [connection signal="timeout" from="ChaseBehavior/ThinkTimer" to="ChaseBehavior" method="_on_ThinkTimer_timeout"]
-[connection signal="timeout" from="DanceBehavior/RunTimer" to="DanceBehavior" method="_on_RunTimer_timeout"]
 [connection signal="timeout" from="DanceBehavior/SyncCheckTimer" to="DanceBehavior" method="_on_SyncCheckTimer_timeout"]
+[connection signal="timeout" from="DanceBehavior/ThinkTimer" to="DanceBehavior" method="_on_ThinkTimer_timeout"]
 [connection signal="timeout" from="DanceBehavior/WaitToDanceTimer" to="DanceBehavior" method="_on_WaitToDanceTimer_timeout"]


### PR DESCRIPTION
This bug resulted in frogs occasionally running too far and snapping back into place.

The old logic used a timer so the frog would run for 8.812 seconds and stop, and then we'd set their position to their target. Sometimes this was off by as much as 60 pixels, resulting in an unpleasant snapping effect.

The new logic uses the frog's position, so the frog runs until they're within a certain radius, and until their velocity would take them further away if they continued running. This is more accurate -- it has theoretical bugs if the radius is too small or there are hiccups where _process() is called with large delta values. But in practice, it is doing what we want.