### PR TITLE
Fixed IntermissionPanelDemo's 'show frog card' key.

### DIFF
--- a/project/src/demo/intermission-panel-demo.gd
+++ b/project/src/demo/intermission-panel-demo.gd
@@ -15,6 +15,7 @@ var number_event: InputEvent
 
 func _ready() -> void:
 	_intermission_panel.show_intermission_panel()
+	_intermission_panel.restart("1-1")
 
 
 func _input(event: InputEvent) -> void:


### PR DESCRIPTION
IntermissionPanelDemo could no longer show frog cards, because there were no cards on screen.