### PR TITLE
Reverted 'cheat code sound bus' bug introduced by evil Godot gnomes

### DIFF
--- a/project/src/main/ui/CheatCodeDetector.tscn
+++ b/project/src/main/ui/CheatCodeDetector.tscn
@@ -10,7 +10,9 @@ script = ExtResource( 3 )
 [node name="CheatDisableSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 1 )
 volume_db = -4.0
+bus = "Sfx"
 
 [node name="CheatEnableSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 2 )
 volume_db = -4.0
+bus = "Sfx"


### PR DESCRIPTION
There is a bug in Godot where opening and closing a .tscn causes completely random changes to happen about 1% of the time.

In commit 716bd98, I opened and saved all .tscn files to revert the signal order to Godot's preferred order. This randomly caused two AudioStreamPlayers to have their bus reverted from the "Sfx" bus to the default "Master" bus.

I've reverted the change.