### PR TITLE
Fixed levels calling show_front before add_card

### DIFF
--- a/project/src/main/froggo-level-rules.gd
+++ b/project/src/main/froggo-level-rules.gd
@@ -345,11 +345,11 @@ func _add_aliax(aliax: String, aliax_cell_pos: Vector2) -> void:
 			_:
 				card.card_front_type = CardControl.CardType.LETTER
 				card.card_front_details = letter.to_lower()
-				if letter == letter.to_upper():
-					card.show_front()
 		if aliax_cell_pos.y == 1:
 			card.card_back_details = "r"
 		level_cards.add_card(card, letter_cell_pos)
+		if card.card_front_type == CardControl.CardType.LETTER and letter == letter.to_upper():
+			card.show_front()
 		_cell_pos_to_revealed_letter[letter_cell_pos] = english_word[i]
 
 

--- a/project/src/main/word-find-level-rules.gd
+++ b/project/src/main/word-find-level-rules.gd
@@ -34,8 +34,8 @@ func add_cards() -> void:
 			var card := level_cards.create_card()
 			card.card_front_type = CardControl.CardType.LETTER
 			card.card_front_details = Utils.rand_value(["a", "d", "e", "h", "i", "k", "n", "s"])
-			card.show_front()
 			level_cards.add_card(card, Vector2(x, y))
+			card.show_front()
 	
 	var _backwards_chance: float = 0.5
 	var _frog_letter_chance: float = 0.5


### PR DESCRIPTION
The onready changes introduced in 64c8db62416892 broke these two levels, because the levels called show_front() before the card's onready variables had been initialized.

The short term fix implemented here is fine, where show_front is called later. A better fix for later would be to have something like a 'front_shown' field which is assigned, and it can be assigned at any time without causing crashes. This has been added as an item for refactoring day.