### PR TITLE
Replaced 'String.erase()' with utility method

### DIFF
--- a/project/src/main/froggo-level-rules.gd
+++ b/project/src/main/froggo-level-rules.gd
@@ -267,7 +267,7 @@ func _reveal_letters(aliax: String, count: int) -> String:
 	
 	for i in letter_indexes:
 		var letter: String = card_word[i]
-		card_word.erase(i, 1)
+		card_word = Utils.erase(card_word, i, 1)
 		card_word = card_word.insert(i, letter.to_upper())
 	
 	return _aliax(card_word, english_word)
@@ -294,7 +294,7 @@ func _replace_letters(aliax: String, replacement: String, chance: float) -> Stri
 		if card_word[i] == card_word[i].to_lower():
 			if shark_count == 0 or randf() < chance:
 				shark_count += 1
-				card_word.erase(i, 1)
+				card_word = Utils.erase(card_word, i, 1)
 				card_word = card_word.insert(i, replacement)
 	
 	return _aliax(card_word, english_word)

--- a/project/src/main/utils.gd
+++ b/project/src/main/utils.gd
@@ -72,3 +72,8 @@ static func subtract(a: Array, b: Array) -> Array:
 		else:
 			result.append(item)
 	return result
+
+
+## Erases 'chars' characters from the string 's' starting from 'position'.
+static func erase(s: String, position: int, chars: int) -> String:
+	return s.left(int(max(position, 0))) + s.substr(position + chars, + s.length() - (position + chars))

--- a/project/src/test/test-utils.gd
+++ b/project/src/test/test-utils.gd
@@ -1,0 +1,15 @@
+extends GutTest
+
+func test_erase_single_character() -> void:
+	assert_eq(Utils.erase("solid", 0, 1), "olid")
+	assert_eq(Utils.erase("solid", 2, 1), "soid")
+	assert_eq(Utils.erase("solid", 4, 1), "soli")
+	assert_eq(Utils.erase("solid", -1, 1), "solid")
+	assert_eq(Utils.erase("solid", 10, 1), "solid")
+
+
+func test_erase_multiple_characters() -> void:
+	assert_eq(Utils.erase("solid", 2, 2), "sod")
+	assert_eq(Utils.erase("solid", 4, 3), "soli")
+	assert_eq(Utils.erase("solid", -1, 3), "lid")
+	assert_eq(Utils.erase("solid", -1, 10), "")


### PR DESCRIPTION
Godot #54869 removes String.erase() in Godot 4. This branch reimplements it as a utility method on our Utils class.