### PR TITLE
Fixed 'randf() < foo' references.

### DIFF
--- a/project/src/demo/LevelRulesDemo.tscn
+++ b/project/src/demo/LevelRulesDemo.tscn
@@ -4,7 +4,7 @@
 [ext_resource path="res://src/main/game-state.gd" type="Script" id=2]
 [ext_resource path="res://src/demo/level-rules-demo.gd" type="Script" id=3]
 [ext_resource path="res://src/main/level-cards.gd" type="Script" id=4]
-[ext_resource path="res://src/main/FroggoLevelRules.tscn" type="PackedScene" id=5]
+[ext_resource path="res://src/main/MazeLevelRules.tscn" type="PackedScene" id=5]
 [ext_resource path="res://src/main/ui/menu/rounded-style-box.tres" type="StyleBox" id=6]
 [ext_resource path="res://src/main/ui/menu/theme/h3.theme" type="Theme" id=7]
 

--- a/project/src/main/maze-level-rules.gd
+++ b/project/src/main/maze-level-rules.gd
@@ -217,7 +217,7 @@ func _before_loose_end_flipped(card: CardControl) -> void:
 	elif _remaining_path_cells <= 0:
 		# if this path is long enough, it's a dead end or a fork
 		var new_arrow_dir_string: String
-		if _loose_end_positions and randf() > (1.0 / (_loose_end_positions.size() + 1)):
+		if _loose_end_positions and randf() < (float(_loose_end_positions.size()) / (_loose_end_positions.size() + 1)):
 			# there are enough loose ends; this one can be a dead end
 			new_arrow_dir_string = ""
 		else:

--- a/project/src/main/pattern-memory-level-rules.gd
+++ b/project/src/main/pattern-memory-level-rules.gd
@@ -182,7 +182,7 @@ func _hidden_lizard_count() -> int:
 
 
 func _before_fish_flipped(fish_card: CardControl) -> void:
-	if randf() > _shark_chance:
+	if randf() < _shark_chance:
 		var shark_card := _shark_card()
 		fish_card.copy_from(shark_card)
 		shark_card.card_front_type = CardControl.CardType.FISH

--- a/project/src/main/running-frog.gd
+++ b/project/src/main/running-frog.gd
@@ -111,10 +111,10 @@ func _randomize_run_style() -> void:
 	run_speed = RUN_SPEED * rand_range(0.8, 1.2)
 	
 	# some running animations are much more common than others
-	if randf() > 0.2:
+	if randf() < 0.8:
 		# arms straight down, like holding suitcases
 		run_animation_name = "run2"
-	elif randf() > 0.2:
+	elif randf() < 0.8:
 		# arms moving up and down, like an exaggerated jog
 		run_animation_name = "run3"
 	else:

--- a/project/src/main/word-find-level-rules.gd
+++ b/project/src/main/word-find-level-rules.gd
@@ -96,7 +96,7 @@ func add_cards() -> void:
 		var word_start := Vector2()
 		word_start.x = _random.randi_range(0, COL_COUNT - 4)
 		word_start.y = _random.randi_range(0, ROW_COUNT - 1)
-		var word := "frog" if randf() > _backwards_chance else "gorf"
+		var word := "gorf" if randf() < _backwards_chance else "frog"
 		for i in range(4):
 			var frog_word_card := level_cards.get_card(Vector2(word_start.x + i, word_start.y))
 			frog_word_card.card_front_details = word[i]
@@ -109,7 +109,7 @@ func add_cards() -> void:
 		var word_start := Vector2()
 		word_start.x = _random.randi_range(0, COL_COUNT - 1)
 		word_start.y = _random.randi_range(0, ROW_COUNT - 4)
-		var word := "frog" if randf() > _backwards_chance else "gorf"
+		var word := "gorf" if randf() < _backwards_chance else "frog"
 		for i in range(4):
 			var frog_word_card := level_cards.get_card(Vector2(word_start.x, word_start.y + i))
 			frog_word_card.card_front_details = word[i]


### PR DESCRIPTION
PatternMemoryLevel had a bug where it was checking 'randf() > shark_chance', leading to an inverse relationship where a higher shark chance resulted in fewer sharks.

I've changed other parts of code to avoid this as well; 'randf() > 0.2' is a misleading and confusing way of coding an 80% chance.