### PR TITLE
set_soon_position() no longer updates the frog's position.

### DIFF
--- a/project/src/main/frog-dance-behavior.gd
+++ b/project/src/main/frog-dance-behavior.gd
@@ -83,6 +83,7 @@ func set_state(new_dance_state: int) -> void:
 		DanceState.WAIT_TO_DANCE:
 			# The frog waits for other frogs to reach their dance targets
 			_frog.set_soon_position(dance_target)
+			_frog.update_position()
 			_frog.velocity = Vector2.ZERO
 			_frog.play_animation("stand")
 			_frog.emit_signal("reached_dance_target")

--- a/project/src/main/intermission-panel.gd
+++ b/project/src/main/intermission-panel.gd
@@ -138,6 +138,7 @@ func _spawn_shark(away_from_hand: bool = false) -> void:
 	var shark: RunningShark = RunningSharkScene.instance()
 	shark.hand = hand
 	shark.soon_position = _random_spawn_point(away_from_hand)
+	shark.update_position()
 	
 	if sharks.size() % 2 == 1:
 		# this shark has a friend
@@ -155,6 +156,7 @@ func _spawn_shark(away_from_hand: bool = false) -> void:
 func _spawn_frog(away_from_hand: bool = false) -> RunningFrog:
 	var frog: RunningFrog = RunningFrogScene.instance()
 	frog.soon_position = _random_spawn_point(away_from_hand)
+	frog.update_position()
 	
 	if frogs.size() % 2 == 1:
 		# this frog has a friend

--- a/project/src/main/running-frog.gd
+++ b/project/src/main/running-frog.gd
@@ -103,7 +103,6 @@ func stop_animation() -> void:
 
 func set_soon_position(new_soon_position: Vector2) -> void:
 	soon_position = new_soon_position
-	position = new_soon_position
 
 
 ## Randomize the frog's running speed and run animation.

--- a/project/src/main/running-shark.gd
+++ b/project/src/main/running-shark.gd
@@ -103,7 +103,6 @@ func is_fed() -> bool:
 
 func set_soon_position(new_soon_position: Vector2) -> void:
 	soon_position = new_soon_position
-	position = new_soon_position
 
 
 func _refresh_run_speed() -> void:


### PR DESCRIPTION
Godot 4 removes the ability for scripts to update their own properties without invoking setters and their corresponding side effects, and it's a better design anyway so I'm applying it to Godot 3 as well.