### PR TITLE
Replace Tween with SceneTreeTween

### DIFF
--- a/project/src/main/Background.tscn
+++ b/project/src/main/Background.tscn
@@ -608,7 +608,3 @@ margin_bottom = 1032.78
 rect_scale = Vector2( -0.771921, 0.681052 )
 texture = ExtResource( 21 )
 expand = true
-
-[node name="ChangeTween" type="Tween" parent="."]
-
-[connection signal="tween_completed" from="ChangeTween" to="." method="_on_ChangeTween_tween_completed"]

--- a/project/src/main/MusicPlayer.tscn
+++ b/project/src/main/MusicPlayer.tscn
@@ -100,7 +100,4 @@ bus = "Music"
 stream = ExtResource( 18 )
 bus = "Music"
 
-[node name="FadeTween" type="Tween" parent="."]
-
 [connection signal="finished" from="FrogDance" to="." method="_on_FrogDance_finished"]
-[connection signal="tween_completed" from="FadeTween" to="." method="_on_FadeTween_tween_completed"]

--- a/project/src/main/background.gd
+++ b/project/src/main/background.gd
@@ -29,7 +29,6 @@ onready var textures := [
 ]
 
 onready var _color_rect := $ColorRect
-onready var _change_tween := $ChangeTween
 
 func _ready() -> void:
 	change(true)
@@ -60,18 +59,18 @@ func change(immediate: bool = false) -> void:
 	else:
 		textures[0].modulate = to_transparent(texture_color)
 		
-		_change_tween.interpolate_property(_color_rect, "color",
-				_color_rect.color, rect_color, TWEEN_DURATION)
-		_change_tween.interpolate_property(textures[0], "modulate",
-				textures[0].modulate, texture_color, TWEEN_DURATION)
-		_change_tween.interpolate_property(previous_texture, "modulate",
-				previous_texture.modulate, to_transparent(previous_texture.modulate), TWEEN_DURATION)
-		_change_tween.start()
+		var change_tween := create_tween().set_parallel()
+		change_tween.tween_property(_color_rect, "color",
+				rect_color, TWEEN_DURATION)
+		change_tween.tween_property(textures[0], "modulate",
+				texture_color, TWEEN_DURATION)
+		change_tween.tween_property(previous_texture, "modulate",
+				to_transparent(previous_texture.modulate), TWEEN_DURATION)
+		change_tween.chain().tween_callback(self, "_on_ChangeTween_tween_completed", [previous_texture])
 
 
-func _on_ChangeTween_tween_completed(object: Object, key: NodePath) -> void:
-	if key == ":modulate" and object.modulate.a == 0.0:
-		object.visible = false
+func _on_ChangeTween_tween_completed(previous_texture: TextureRect) -> void:
+	previous_texture.visible = false
 
 
 ## Returns a transparent version of the specified color.


### PR DESCRIPTION
Godot 4 is removing the Tween node, so I've replaced all Tween references with SceneTreetWeens.