### PR TITLE
Replaced 'if foo' with 'if not foo.empty()'

### DIFF
--- a/project/src/main/fruit-maze-rules.gd
+++ b/project/src/main/fruit-maze-rules.gd
@@ -325,7 +325,7 @@ func _hide_outer_fruits() -> void:
 
 
 func _before_premature_frog_flipped(card: CardControl) -> void:
-	if not _wrong_outer_fruit_cells_by_details:
+	if _wrong_outer_fruit_cells_by_details.empty():
 		# can't swap the frog out; there's nobody to swap with
 		return
 	

--- a/project/src/main/level-rules.gd
+++ b/project/src/main/level-rules.gd
@@ -24,7 +24,7 @@ func set_level_cards_path(new_level_cards_path: NodePath) -> void:
 
 
 func refresh_level_cards_path() -> void:
-	if not is_inside_tree() or not level_cards_path:
+	if not is_inside_tree() or level_cards_path.is_empty():
 		return
 	
 	level_cards = get_node(level_cards_path) if level_cards_path else null

--- a/project/src/main/maze-level-rules.gd
+++ b/project/src/main/maze-level-rules.gd
@@ -263,7 +263,7 @@ func _on_LevelCards_before_card_flipped(card: CardControl) -> void:
 		var old_card: CardControl = _shown_card_queue.pop_front()
 		old_card.hide_front()
 	
-	if card.card_front_type == CardControl.CardType.ARROW and card.card_front_details:
+	if card.card_front_type == CardControl.CardType.ARROW and not card.card_front_details.empty():
 		_unblanked_arrow_queue.append(card)
 	if _unblanked_arrow_queue.size() > _max_unblanked_arrow_count:
 		var old_card: CardControl = _unblanked_arrow_queue.pop_front()

--- a/project/src/main/pattern-memory-level-rules.gd
+++ b/project/src/main/pattern-memory-level-rules.gd
@@ -161,7 +161,7 @@ func _before_lizard_flipped(lizard_card: CardControl) -> void:
 	if _remaining_cards_without_hiding > 0:
 		_remaining_cards_without_hiding -= 1
 		remaining_cards_to_hide = 0
-	while _unhidden_cards and remaining_cards_to_hide:
+	while not _unhidden_cards.empty() and remaining_cards_to_hide > 0:
 		var card: CardControl = _unhidden_cards.pop_front()
 		card.hide_front()
 		remaining_cards_to_hide -= 1

--- a/project/src/main/secret-collect-level-rules.gd
+++ b/project/src/main/secret-collect-level-rules.gd
@@ -99,7 +99,7 @@ func add_cards() -> void:
 	var potential_secret_positions := []
 	var potential_fish_positions := remaining_card_positions.duplicate()
 	for _i in range(fish_count):
-		if not potential_fish_positions:
+		if potential_fish_positions.empty():
 			# no more fish positions
 			break
 		
@@ -114,7 +114,7 @@ func add_cards() -> void:
 	# add secrets
 	potential_secret_positions.shuffle()
 	for i in range(secret_count):
-		if not potential_secret_positions:
+		if potential_secret_positions.empty():
 			# no more secret positions
 			break
 		

--- a/project/src/main/utils.gd
+++ b/project/src/main/utils.gd
@@ -43,7 +43,7 @@ static func assign_card_texture(sprite: Sprite, texture: Texture) -> void:
 
 ## Gets the substring after the first occurrence of a separator.
 static func substring_after(s: String, sep: String) -> String:
-	if not sep:
+	if sep.empty():
 		return s
 	var pos := s.find(sep)
 	return "" if pos == -1 else s.substr(pos + sep.length())


### PR DESCRIPTION
Godot 3.x let us treat integers/arrays/dictionaries as boolean values, but Godot 4.x doesn't let us do that anymore. In preparation for the Godot 4 upgrade, I'm replacing these references.

Removed redundant integer division warning in frodoku-level-rules.gd.