### PR TITLE
Restoring rounded UI corners.

### DIFF
--- a/project/src/demo/LevelRulesDemo.tscn
+++ b/project/src/demo/LevelRulesDemo.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=7 format=3 uid="uid://dyjb7fgm2j5yu"]
+[gd_scene load_steps=8 format=3 uid="uid://dyjb7fgm2j5yu"]
 
 [ext_resource type="Script" path="res://src/main/gameplay-panel.gd" id="1"]
 [ext_resource type="Script" path="res://src/main/game-state.gd" id="2"]
 [ext_resource type="PackedScene" uid="uid://bvbj13mtdoy4q" path="res://src/main/WordFindLevelRules.tscn" id="2_xbu18"]
 [ext_resource type="Script" path="res://src/demo/level-rules-demo.gd" id="3"]
+[ext_resource type="StyleBox" uid="uid://dwuudlvawkj6" path="res://src/main/ui/menu/rounded-style-box.tres" id="3_qswrx"]
 [ext_resource type="Script" path="res://src/main/level-cards.gd" id="4"]
 [ext_resource type="Theme" uid="uid://bf6pj7hmxiojs" path="res://src/main/ui/menu/theme/h3.theme" id="7"]
 
@@ -19,6 +20,7 @@ offset_left = 50.0
 offset_top = 50.0
 offset_right = -50.0
 offset_bottom = -50.0
+theme_override_styles/panel = ExtResource("3_qswrx")
 script = ExtResource("1")
 
 [node name="GameState" type="Node" parent="GameplayPanel"]

--- a/project/src/main/IntermissionPanel.tscn
+++ b/project/src/main/IntermissionPanel.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=8 format=3 uid="uid://ppmbm3tpkrj0"]
+[gd_scene load_steps=9 format=3 uid="uid://ppmbm3tpkrj0"]
 
 [ext_resource type="Script" path="res://src/main/intermission-panel.gd" id="1"]
+[ext_resource type="StyleBox" uid="uid://dwuudlvawkj6" path="res://src/main/ui/menu/rounded-style-box.tres" id="1_ygcmr"]
 [ext_resource type="Script" path="res://src/main/level-cards.gd" id="2"]
 [ext_resource type="Script" path="res://src/main/game-state.gd" id="3"]
 [ext_resource type="Script" path="res://src/main/ui/menu/clickable-icon.gd" id="4"]
@@ -14,6 +15,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_styles/panel = ExtResource("1_ygcmr")
 script = ExtResource("1")
 
 [node name="IntermissionState" type="Node" parent="."]

--- a/project/src/main/MainMenu.tscn
+++ b/project/src/main/MainMenu.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=10 format=3 uid="uid://ctg1buedvhl85"]
+[gd_scene load_steps=11 format=3 uid="uid://ctg1buedvhl85"]
 
 [ext_resource type="PackedScene" uid="uid://dblxk2xi71xu3" path="res://src/main/ui/CheatCodeDetector.tscn" id="1"]
 [ext_resource type="PackedScene" uid="uid://dumlnqf4q370u" path="res://src/main/MenuState.tscn" id="2"]
 [ext_resource type="PackedScene" uid="uid://chis4b4c44mwo" path="res://src/main/MainMenuPanel.tscn" id="4"]
+[ext_resource type="StyleBox" uid="uid://dwuudlvawkj6" path="res://src/main/ui/menu/rounded-style-box.tres" id="4_hain8"]
 [ext_resource type="Script" path="res://src/main/game-state.gd" id="5"]
 [ext_resource type="Script" path="res://src/main/gameplay-panel.gd" id="6"]
 [ext_resource type="Script" path="res://src/main/level-cards.gd" id="13"]
@@ -51,6 +52,7 @@ offset_left = 50.0
 offset_top = 50.0
 offset_right = -50.0
 offset_bottom = -50.0
+theme_override_styles/panel = ExtResource("4_hain8")
 script = ExtResource("6")
 
 [node name="GameState" type="Node" parent="Content/GameplayPanel"]

--- a/project/src/main/MainMenuPanel.tscn
+++ b/project/src/main/MainMenuPanel.tscn
@@ -1,5 +1,6 @@
-[gd_scene load_steps=23 format=3 uid="uid://chis4b4c44mwo"]
+[gd_scene load_steps=24 format=3 uid="uid://chis4b4c44mwo"]
 
+[ext_resource type="StyleBox" uid="uid://dwuudlvawkj6" path="res://src/main/ui/menu/rounded-style-box.tres" id="1_kndqk"]
 [ext_resource type="Script" path="res://src/main/game-state.gd" id="2"]
 [ext_resource type="PackedScene" uid="uid://dp8d8k3cis08f" path="res://src/main/WowSprite.tscn" id="3"]
 [ext_resource type="Script" path="res://src/main/main-menu-panel.gd" id="4"]
@@ -29,6 +30,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_styles/panel = ExtResource("1_kndqk")
 script = ExtResource("4")
 
 [node name="WorldDecorationHolder" type="Control" parent="."]
@@ -273,18 +275,24 @@ script = ExtResource("20")
 anchors_preset = 0
 anchor_right = 0.0
 anchor_bottom = 0.0
+grow_horizontal = 1
+grow_vertical = 1
 
 [node name="World2Buttons" parent="LevelButtonHolder" instance=ExtResource("9")]
 visible = false
 anchors_preset = 0
 anchor_right = 0.0
 anchor_bottom = 0.0
+grow_horizontal = 1
+grow_vertical = 1
 
 [node name="World3Buttons" parent="LevelButtonHolder" instance=ExtResource("17")]
 visible = false
 anchors_preset = 0
 anchor_right = 0.0
 anchor_bottom = 0.0
+grow_horizontal = 1
+grow_vertical = 1
 
 [node name="TitleGameState" type="Node" parent="."]
 script = ExtResource("2")

--- a/project/src/main/ui/menu/rounded-style-box.tres
+++ b/project/src/main/ui/menu/rounded-style-box.tres
@@ -1,7 +1,7 @@
-[gd_resource type="StyleBoxFlat" format=2]
+[gd_resource type="StyleBoxFlat" format=3 uid="uid://dwuudlvawkj6"]
 
 [resource]
-bg_color = Color( 0, 0, 0, 0.376471 )
+bg_color = Color(0, 0, 0, 0.376471)
 corner_radius_top_left = 20
 corner_radius_top_right = 20
 corner_radius_bottom_right = 20


### PR DESCRIPTION
Rounded UI corners were disabled during the Godot 4.x upgrade. It unassigned our theme overrides.

Closes #185.