### PR TITLE
Update rendering mode to 'Compatibility'.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -41,3 +41,7 @@ enabled=PackedStringArray("res://addons/gut/plugin.cfg")
 [global]
 
 mouse=false
+
+[rendering]
+
+renderer/rendering_method="gl_compatibility"


### PR DESCRIPTION
Workaround for Godot #71350. The Vulkan rendering backends are complex and require a long time to start (about 10 seconds). The resulting graphical enhancements are worth it, but during development I prefer the faster loading times of the Compatibility renderer.

https://github.com/godotengine/godot/issues/71350