### PR TITLE
Refactor: Avoid 'randf >', functions missing type hint

### DIFF
--- a/delint.sh
+++ b/delint.sh
@@ -87,6 +87,16 @@ then
   echo "$RESULT"
 fi
 
+# functions missing type hint
+RESULT=$(grep -R -n "func [a-zA-Z0-9_]*([a-zA-Z0-9_]\+[,)]" --include="*.gd" project/src \
+  )
+if [ -n "$RESULT" ]
+then
+  echo ""
+  echo "Functions missing type hint:"
+  echo "$RESULT"
+fi
+
 # temporary files
 RESULT=$(find project/src -name "*.TMP" -o -name "*.gd~")
 if [ -n "$RESULT" ]
@@ -138,6 +148,7 @@ fi
 
 # print statements that got left in by mistake
 RESULT=$(git diff main | grep print\()
+RESULT=$(git diff main | grep print_debug\()
 if [ -n "$RESULT" ]
 then
   echo ""

--- a/project/src/main/word-find-level-rules.gd
+++ b/project/src/main/word-find-level-rules.gd
@@ -120,7 +120,7 @@ func add_cards() -> void:
 		if card_obj in _frog_word_cards:
 			continue
 		
-		if randf() > _frog_letter_chance:
+		if not randf() < _frog_letter_chance:
 			continue
 		
 		var card: CardControl = card_obj
@@ -141,7 +141,7 @@ func add_cards() -> void:
 		if card_obj in _frog_word_cards:
 			continue
 		
-		if randf() > _fish_letter_chance:
+		if not randf() < _fish_letter_chance:
 			continue
 		
 		var card: CardControl = card_obj


### PR DESCRIPTION
At a glance, stuff like 'randf() > 0.35' looks like a 35% chance and 'randf() < 1.0' looks like a 100% chance. It takes a little more thought and mental arithmetic to figure out what it's actually doing. 'randf() <= 0.65' is easier to read.

Added delinting rule for functions missing type hint. No frog finder methods are missing type hints.