### PR TITLE
Refactoring: Godot #58285, Godot #76267

### DIFF
--- a/project/src/main/card-control.gd
+++ b/project/src/main/card-control.gd
@@ -223,14 +223,10 @@ func _refresh_card_face(card_sprite: Sprite2D, card_type: int, card_details: Str
 		CardType.FROG:
 			Utils.assign_card_texture(card_sprite, _frog_sheet)
 			var frog_index := randi() % FROG_COUNT
-			# workaround for Godot #58285 (https://github.com/godotengine/godot/issues/58285); typed arrays don't work
-			# with setters
 			card_sprite.wiggle_frames = [4 * frog_index + 0, 4 * frog_index + 1] as Array[int]
 		CardType.SHARK:
 			Utils.assign_card_texture(card_sprite, _shark_sheet)
 			var shark_index := randi() % SHARK_COUNT
-			# workaround for Godot #58285 (https://github.com/godotengine/godot/issues/58285); typed arrays don't work
-			# with setters
 			card_sprite.wiggle_frames = [2 * shark_index + 0, 2 * shark_index + 1] as Array[int]
 		CardType.MYSTERY:
 			Utils.assign_card_texture(card_sprite, _mystery_sheet)
@@ -240,8 +236,6 @@ func _refresh_card_face(card_sprite: Sprite2D, card_type: int, card_details: Str
 				mystery_index = Utils.rand_value(mystery_indexes)
 			else:
 				mystery_index = randi() % MYSTERY_COUNT
-			# workaround for Godot #58285 (https://github.com/godotengine/godot/issues/58285); typed arrays don't work
-			# with setters
 			card_sprite.wiggle_frames = [2 * mystery_index + 0, 2 * mystery_index + 1] as Array[int]
 		CardType.LETTER:
 			Utils.assign_card_texture(card_sprite, _letter_sheet)
@@ -253,8 +247,6 @@ func _refresh_card_face(card_sprite: Sprite2D, card_type: int, card_details: Str
 				# We never want random letters in a level. If this is happening, something is wrong.
 				_pending_warning = "Unrecognized letter: %s" % [card_details]
 				letter_index = randi() % LETTER_COUNT
-			# workaround for Godot #58285 (https://github.com/godotengine/godot/issues/58285); typed arrays don't work
-			# with setters
 			card_sprite.wiggle_frames = [2 * letter_index + 0, 2 * letter_index + 1] as Array[int]
 		CardType.ARROW:
 			Utils.assign_card_texture(card_sprite, _arrow_sheet)
@@ -266,8 +258,6 @@ func _refresh_card_face(card_sprite: Sprite2D, card_type: int, card_details: Str
 				# We never want random arrows in a level. If this is happening, something is wrong.
 				_pending_warning = "Unrecognized arrow: %s" % [card_details]
 				arrow_index = randi() % ARROW_COUNT
-			# workaround for Godot #58285 (https://github.com/godotengine/godot/issues/58285); typed arrays don't work
-			# with setters
 			card_sprite.wiggle_frames = [2 * arrow_index + 0, 2 * arrow_index + 1] as Array[int]
 		CardType.HEX_ARROW:
 			Utils.assign_card_texture(card_sprite, _hex_arrow_sheet)
@@ -279,20 +269,14 @@ func _refresh_card_face(card_sprite: Sprite2D, card_type: int, card_details: Str
 				# We never want random arrows in a level. If this is happening, something is wrong.
 				_pending_warning = "Unrecognized hex arrow: %s" % [card_details]
 				arrow_index = randi() % HEX_ARROW_COUNT
-			# workaround for Godot #58285 (https://github.com/godotengine/godot/issues/58285); typed arrays don't work
-			# with setters
 			card_sprite.wiggle_frames = [2 * arrow_index + 0, 2 * arrow_index + 1] as Array[int]
 		CardType.FISH:
 			Utils.assign_card_texture(card_sprite, _fish_sheet)
 			var fish_index := randi() % FISH_COUNT
-			# workaround for Godot #58285 (https://github.com/godotengine/godot/issues/58285); typed arrays don't work
-			# with setters
 			card_sprite.wiggle_frames = [2 * fish_index + 0, 2 * fish_index + 1] as Array[int]
 		CardType.LIZARD:
 			Utils.assign_card_texture(card_sprite, _lizard_sheet)
 			var lizard_index := randi() % LIZARD_COUNT
-			# workaround for Godot #58285 (https://github.com/godotengine/godot/issues/58285); typed arrays don't work
-			# with setters
 			card_sprite.wiggle_frames = [2 * lizard_index + 0, 2 * lizard_index + 1] as Array[int]
 		CardType.FRUIT:
 			Utils.assign_card_texture(card_sprite, _fruit_sheet)
@@ -303,8 +287,6 @@ func _refresh_card_face(card_sprite: Sprite2D, card_type: int, card_details: Str
 				# We never want random arrows in a level. If this is happening, something is wrong.
 				_pending_warning = "Unrecognized fruit: %s" % [card_details]
 				fruit_index = randi() % FRUIT_COUNT
-			# workaround for Godot #58285 (https://github.com/godotengine/godot/issues/58285); typed arrays don't work
-			# with setters
 			card_sprite.wiggle_frames = [2 * fruit_index + 0, 2 * fruit_index + 1] as Array[int]
 	
 	if card_sprite.wiggle_frames:
@@ -420,8 +402,6 @@ func cheer() -> void:
 		return
 	
 	var frog_index := int(_card_front_sprite.wiggle_frames[0] / 4)
-	# workaround for Godot #58285 (https://github.com/godotengine/godot/issues/58285); typed arrays don't work with
-	# setters
 	_card_front_sprite.wiggle_frames = [frog_index * 4 + 2, frog_index * 4 + 3] as Array[int]
 	var wiggle_index: int = _card_front_sprite.frame % _card_front_sprite.wiggle_frames.size()
 	_card_front_sprite.frame = _card_front_sprite.wiggle_frames[wiggle_index]

--- a/project/src/main/finger-sprite.gd
+++ b/project/src/main/finger-sprite.gd
@@ -43,6 +43,8 @@ func _ready() -> void:
 ## Parameters:
 ## 	'finger_index': 2 = pinky finger, 1 = naughty finger, 0 = pointer finger
 func bite(finger_index: int) -> void:
+	# Workaround for Godot #72627 (https://github.com/godotengine/godot/issues/72627); Cannot cast typed arrays using
+	# type hints
 	wiggle_frames.assign(WIGGLE_FRAMES_BY_BITTEN_FINGER[finger_index])
 	_wiggle_timer.assign_wiggle_frame()
 	

--- a/project/src/main/frog-dance-behavior.gd
+++ b/project/src/main/frog-dance-behavior.gd
@@ -160,9 +160,9 @@ func _decide_dance_names() -> Array:
 	for _i in range(4):
 		var possible_dance_names: Array[String] = _dance_animations.dance_names
 		if not result.is_empty():
-			# workaround for Godot #72627 (https://github.com/godotengine/godot/issues/72627); cannot cast typed arrays
-			# using type hints
 			var new_dance_names: Array[String] = []
+			# workaround for Godot #72627 (https://github.com/godotengine/godot/issues/72627); Cannot cast typed arrays using
+			# type hints
 			new_dance_names.assign(Utils.subtract(possible_dance_names, [result.back()]))
 			possible_dance_names = new_dance_names
 		result.append(Utils.rand_value(possible_dance_names))

--- a/project/src/main/hand.gd
+++ b/project/src/main/hand.gd
@@ -101,21 +101,11 @@ func _refresh_hand_sprite() -> void:
 	
 	if huggable_fingers > 0:
 		match hugged_fingers:
-			# workaround for Godot #58285 (https://github.com/godotengine/godot/issues/58285); typed arrays don't work
-			# with setters
 			0: _hug_sprite.wiggle_frames = [0] as Array[int]
-			# workaround for Godot #58285 (https://github.com/godotengine/godot/issues/58285); typed arrays don't work
-			# with setters
 			1: _hug_sprite.wiggle_frames = [1, 2] as Array[int]
-			# workaround for Godot #58285 (https://github.com/godotengine/godot/issues/58285); typed arrays don't work
-			# with setters
 			2: _hug_sprite.wiggle_frames = [3, 4] as Array[int]
-			# workaround for Godot #58285 (https://github.com/godotengine/godot/issues/58285); typed arrays don't work
-			# with setters
 			3: _hug_sprite.wiggle_frames = [5, 6] as Array[int]
 	else:
-		# workaround for Godot #58285 (https://github.com/godotengine/godot/issues/58285); typed arrays don't work
-		# with setters
 		_hug_sprite.wiggle_frames = [] as Array[int]
 		_hug_sprite.frame = 0
 	

--- a/project/src/main/music-control.gd
+++ b/project/src/main/music-control.gd
@@ -25,8 +25,8 @@ func _refresh_sprite() -> void:
 	if not is_inside_tree():
 		return
 	
-	# workaround for Godot #58285 (https://github.com/godotengine/godot/issues/58285); typed arrays don't work with
-	# setters
+	# workaround for Godot #72627 (https://github.com/godotengine/godot/issues/72627); Cannot cast typed arrays using
+	# type hints
 	_sprite.wiggle_frames.assign(WIGGLE_FRAMES_BY_MUSIC_PREFERENCE[PlayerData.music_preference])
 	_sprite.assign_wiggle_frame()
 

--- a/project/src/main/ui/menu/clickable-icon.gd
+++ b/project/src/main/ui/menu/clickable-icon.gd
@@ -42,7 +42,5 @@ func _refresh_sprite() -> void:
 		return
 	
 	Utils.assign_card_texture(_icon_sprite, icon_texture)
-	# workaround for Godot #58285 (https://github.com/godotengine/godot/issues/58285); typed arrays don't work with
-	# setters
 	_icon_sprite.wiggle_frames = [2 * icon_index + 0, 2 * icon_index + 1] as Array[int]
 	_icon_sprite.assign_wiggle_frame()

--- a/project/src/main/ui/menu/wide-wow-sprite.gd
+++ b/project/src/main/ui/menu/wide-wow-sprite.gd
@@ -10,16 +10,20 @@ const ALL_LEFT_WIGGLE_FRAMES := [[0, 2], [4, 6], [8, 10], [12, 14]]
 ## List of potential wiggle frame pairs corresponding to the right half of a 'wow sprite'
 const ALL_RIGHT_WIGGLE_FRAMES := [[1, 3], [5, 7], [9, 11], [13, 15]]
 
-var _left_wiggle_frames := []
-var _right_wiggle_frames := []
+var _left_wiggle_frames: Array[int] = []
+var _right_wiggle_frames: Array[int] = []
 
 @onready var _wiggle_timer := $WiggleTimer
 @onready var _left := $Left
 @onready var _right := $Right
 
 func _ready() -> void:
-	_left_wiggle_frames = Utils.rand_value(ALL_LEFT_WIGGLE_FRAMES)
-	_right_wiggle_frames = Utils.rand_value(ALL_RIGHT_WIGGLE_FRAMES)
+	# workaround for Godot #72627 (https://github.com/godotengine/godot/issues/72627); Cannot cast typed arrays using
+	# type hints
+	_left_wiggle_frames.assign(Utils.rand_value(ALL_LEFT_WIGGLE_FRAMES))
+	# workaround for Godot #72627 (https://github.com/godotengine/godot/issues/72627); Cannot cast typed arrays using
+	# type hints
+	_right_wiggle_frames.assign(Utils.rand_value(ALL_RIGHT_WIGGLE_FRAMES))
 	reset_wiggle()
 
 


### PR DESCRIPTION
Removed mention of Godot #58285 -- this issue never really applied to our project, since 'wiggle_frames' does not have a setter anyways. The 'workaround' of requiring an explicit cast seems to be working as intended.

About 90% of our array assignments work, and 10% of them do not. I don't understand what the pattern is, but I've documented the remaining 10% with references to Godot #72627.