### PR TITLE
Refactoring: min_volume, blender, texture.get_width

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -39,6 +39,10 @@ window/stretch/aspect="expand"
 
 enabled=PackedStringArray("res://addons/gut/plugin.cfg")
 
+[filesystem]
+
+import/blender/enabled=false
+
 [global]
 
 mouse=false

--- a/project/src/main/card-control.gd
+++ b/project/src/main/card-control.gd
@@ -442,8 +442,6 @@ func _on_StopDanceTimer_timeout() -> void:
 		return
 	
 	var frog_index := int(_card_front_sprite.wiggle_frames[0] / 4)
-	# workaround for Godot #58285 (https://github.com/godotengine/godot/issues/58285); typed arrays don't work with
-	# setters
 	_card_front_sprite.wiggle_frames = [frog_index * 4 + 0, frog_index * 4 + 1] as Array[int]
 
 

--- a/project/src/main/music-player.gd
+++ b/project/src/main/music-player.gd
@@ -204,7 +204,7 @@ func _fade(song: AudioStreamPlayer, new_volume_db: float, duration: float) -> vo
 	var fade_tween: Tween = _tweens_by_song[song]
 	fade_tween.tween_property(song, "volume_db", new_volume_db, duration)
 	
-	if new_volume_db == MIN_VOLUME:
+	if is_equal_approx(new_volume_db, MIN_VOLUME):
 		## stop playback after music fades out
 		fade_tween.tween_callback(_current_song.stop)
 

--- a/project/src/main/utils.gd
+++ b/project/src/main/utils.gd
@@ -31,9 +31,9 @@ static func rand_value(values: Array):
 static func assign_card_texture(sprite: Sprite2D, texture: Texture2D) -> void:
 	sprite.texture = texture
 	@warning_ignore("integer_division")
-	sprite.hframes = int(ceil(texture.get_width() / 240))
+	sprite.hframes = int(ceil(texture.get_width() / 240)) if texture != null else 1
 	@warning_ignore("integer_division")
-	sprite.vframes = int(ceil(texture.get_height() / 240))
+	sprite.vframes = int(ceil(texture.get_height() / 240)) if texture != null else 1
 
 
 ## Gets the substring after the first occurrence of a separator.


### PR DESCRIPTION
Our old code was comparing a float value 'MIN_VOLUME' using ==. I've changed it to use 'is_equal_approx'

Fixed warning which popped up in the editor in 'assign_card_texture' complaining because the texture was null.

Fixed warning about blender file imports.

Removed remaining Godot #58285 comment.