### PR TITLE
Refactor: private exports, 'autotile' comments

### DIFF
--- a/project/src/main/MainMenu.tscn
+++ b/project/src/main/MainMenu.tscn
@@ -22,11 +22,11 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 
 [node name="MenuState" parent="Content" instance=ExtResource("2")]
-_main_menu_panel_path = NodePath("../MainMenuPanel")
-_gameplay_panel_path = NodePath("../GameplayPanel")
-_intermission_panel_path = NodePath("../IntermissionPanel")
-_hand_path = NodePath("../../Hand")
-_background_path = NodePath("../Background")
+main_menu_panel_path = NodePath("../MainMenuPanel")
+gameplay_panel_path = NodePath("../GameplayPanel")
+intermission_panel_path = NodePath("../IntermissionPanel")
+hand_path = NodePath("../../Hand")
+background_path = NodePath("../Background")
 
 [node name="Background" parent="Content" instance=ExtResource("18")]
 layout_mode = 1

--- a/project/src/main/dance-animations.gd
+++ b/project/src/main/dance-animations.gd
@@ -41,7 +41,7 @@ const NON_DANCE_ANIMS := [
 ## frames used for each dance.
 func update_dances(value: bool) -> void:
 	if not value:
-		# only autotile in the editor when the 'flip_dances' property is toggled
+		# only update dances in the editor when the '_update_dances' property is toggled
 		return
 	
 	_flip_animations()

--- a/project/src/main/menu-state.gd
+++ b/project/src/main/menu-state.gd
@@ -1,17 +1,17 @@
 extends Node
 ## Tracks which panel should be shown: The main menu panel, gameplay panel, or intermission panel.
 
-@export var _main_menu_panel_path: NodePath
-@export var _gameplay_panel_path: NodePath
-@export var _intermission_panel_path: NodePath
-@export var _hand_path: NodePath
-@export var _background_path: NodePath
+@export var main_menu_panel_path: NodePath
+@export var gameplay_panel_path: NodePath
+@export var intermission_panel_path: NodePath
+@export var hand_path: NodePath
+@export var background_path: NodePath
 
-@onready var _main_menu_panel: MainMenuPanel = get_node(_main_menu_panel_path)
-@onready var _gameplay_panel: GameplayPanel = get_node(_gameplay_panel_path)
-@onready var _intermission_panel: IntermissionPanel = get_node(_intermission_panel_path)
-@onready var _hand: Hand = get_node(_hand_path)
-@onready var _background: Background = get_node(_background_path)
+@onready var _main_menu_panel: MainMenuPanel = get_node(main_menu_panel_path)
+@onready var _gameplay_panel: GameplayPanel = get_node(gameplay_panel_path)
+@onready var _intermission_panel: IntermissionPanel = get_node(intermission_panel_path)
+@onready var _hand: Hand = get_node(hand_path)
+@onready var _background: Background = get_node(background_path)
 
 ## Holds all temporary timers. These timers are not created by get_tree().create_timer() because we need to clean them
 ## up if the game is interrupted. Otherwise for example, we might schedule an intermission to appear 3 seconds from


### PR DESCRIPTION
Fixed private export variables in menu-state.gd. We occasionally use private export variables for weird editor-specific kludges, but in general all export variables should be public.

Fixed comments in dance-animations.gd which mentioned 'autotiling' and 'flip_dances', which were both inaccurate.