### PR TITLE
Reduce churn for ComicTitle scene

### DIFF
--- a/project/src/main/comic/comic-letter.gd
+++ b/project/src/main/comic/comic-letter.gd
@@ -59,6 +59,9 @@ func hide_letter() -> void:
 
 
 func set_text(new_text: String) -> void:
+	if text == new_text:
+		return
+	
 	text = new_text
 	_refresh_text()
 


### PR DESCRIPTION
Comic titles constantly change their frames and materials. Some of this seems unavoidable (I think Godot recreates materials in the editor constantly if you set the 'Local To Scene' flag, or something like that), but I've made some changes that seem to help slightly.

ComicLetter no longer stores its LetterNodes. This was introducing edge cases in the editor where its title and its nodes were out of sync.