### PR TITLE
Removed NodePath exports.

### DIFF
--- a/project/src/demo/IntermissionPanelDemo.tscn
+++ b/project/src/demo/IntermissionPanelDemo.tscn
@@ -7,11 +7,11 @@
 [node name="Demo" type="Node"]
 script = ExtResource("2")
 
-[node name="IntermissionPanel" parent="." instance=ExtResource("1")]
+[node name="IntermissionPanel" parent="." node_paths=PackedStringArray("hand") instance=ExtResource("1")]
 offset_left = 50.0
 offset_top = 50.0
 offset_right = -50.0
 offset_bottom = -50.0
-hand_path = NodePath("../Hand")
+hand = NodePath("../Hand")
 
 [node name="Hand" parent="." instance=ExtResource("3")]

--- a/project/src/demo/LevelRulesDemo.tscn
+++ b/project/src/demo/LevelRulesDemo.tscn
@@ -30,14 +30,14 @@ script = ExtResource("2")
 wait_time = 0.1
 one_shot = true
 
-[node name="LevelCards" type="Control" parent="GameplayPanel"]
+[node name="LevelCards" type="Control" parent="GameplayPanel" node_paths=PackedStringArray("game_state")]
 anchors_preset = 0
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
 script = ExtResource("4")
-game_state_path = NodePath("../GameState")
+game_state = NodePath("../GameState")
 
 [node name="DifficultyLabel" type="Label" parent="."]
 modulate = Color(1, 1, 1, 0.313726)

--- a/project/src/main/CardControl.tscn
+++ b/project/src/main/CardControl.tscn
@@ -11,7 +11,6 @@ anchors_preset = 0
 offset_right = 80.0
 offset_bottom = 80.0
 script = ExtResource("3")
-game_state_path = NodePath("")
 
 [node name="CardBack" parent="." instance=ExtResource("2")]
 

--- a/project/src/main/GameplayPanel.tscn
+++ b/project/src/main/GameplayPanel.tscn
@@ -17,8 +17,8 @@ offset_bottom = -50.0
 theme_override_styles/panel = ExtResource("1_hyfi8")
 script = ExtResource("2_5x0xm")
 
-[node name="CardShadows" parent="." instance=ExtResource("3_25m06")]
-ParentPanelPath = NodePath("..")
+[node name="CardShadows" parent="." node_paths=PackedStringArray("parent_panel") instance=ExtResource("3_25m06")]
+parent_panel = NodePath("..")
 
 [node name="GameState" type="Node" parent="."]
 script = ExtResource("4_kg84t")
@@ -27,14 +27,14 @@ script = ExtResource("4_kg84t")
 wait_time = 0.1
 one_shot = true
 
-[node name="LevelCards" type="Control" parent="."]
+[node name="LevelCards" type="Control" parent="." node_paths=PackedStringArray("game_state")]
 anchors_preset = 0
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
 script = ExtResource("5_8swc1")
-game_state_path = NodePath("../GameState")
+game_state = NodePath("../GameState")
 
 [connection signal="before_frog_found" from="LevelCards" to="." method="_on_level_cards_before_frog_found"]
 [connection signal="before_shark_found" from="LevelCards" to="." method="_on_level_cards_before_shark_found"]

--- a/project/src/main/IntermissionPanel.tscn
+++ b/project/src/main/IntermissionPanel.tscn
@@ -19,8 +19,8 @@ grow_vertical = 2
 theme_override_styles/panel = ExtResource("1_ygcmr")
 script = ExtResource("1")
 
-[node name="CardShadows" parent="." instance=ExtResource("2_3o2pr")]
-ParentPanelPath = NodePath("..")
+[node name="CardShadows" parent="." node_paths=PackedStringArray("parent_panel") instance=ExtResource("2_3o2pr")]
+parent_panel = NodePath("..")
 
 [node name="IntermissionState" type="Node" parent="."]
 script = ExtResource("3")
@@ -30,7 +30,7 @@ can_interact = false
 wait_time = 0.1
 one_shot = true
 
-[node name="IntermissionCards" type="Control" parent="."]
+[node name="IntermissionCards" type="Control" parent="." node_paths=PackedStringArray("game_state")]
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
@@ -40,7 +40,7 @@ anchor_bottom = 0.5
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("2")
-game_state_path = NodePath("../IntermissionState")
+game_state = NodePath("../IntermissionState")
 
 [node name="SharkSpawnTimer" type="Timer" parent="."]
 wait_time = 8.0

--- a/project/src/main/MainMenu.tscn
+++ b/project/src/main/MainMenu.tscn
@@ -23,12 +23,12 @@ anchors_preset = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 
-[node name="MenuState" parent="Content" instance=ExtResource("2")]
-main_menu_panel_path = NodePath("../MainMenuPanel")
-gameplay_panel_path = NodePath("../GameplayPanel")
-intermission_panel_path = NodePath("../IntermissionPanel")
-hand_path = NodePath("../../Hand")
-background_path = NodePath("../Background")
+[node name="MenuState" parent="Content" node_paths=PackedStringArray("main_menu_panel", "gameplay_panel", "intermission_panel", "hand", "background") instance=ExtResource("2")]
+main_menu_panel = NodePath("../MainMenuPanel")
+gameplay_panel = NodePath("../GameplayPanel")
+intermission_panel = NodePath("../IntermissionPanel")
+hand = NodePath("../../Hand")
+background = NodePath("../Background")
 
 [node name="Background" parent="Content" instance=ExtResource("18")]
 layout_mode = 1
@@ -46,7 +46,7 @@ visible = false
 layout_mode = 1
 anchors_preset = -1
 
-[node name="IntermissionPanel" parent="Content" instance=ExtResource("15")]
+[node name="IntermissionPanel" parent="Content" node_paths=PackedStringArray("hand") instance=ExtResource("15")]
 visible = false
 layout_mode = 1
 anchors_preset = -1
@@ -54,9 +54,9 @@ offset_left = 50.0
 offset_top = 50.0
 offset_right = -50.0
 offset_bottom = -50.0
-hand_path = NodePath("../../Hand")
+hand = NodePath("../../Hand")
 
-[node name="ComicManager" type="Control" parent="Content"]
+[node name="ComicManager" type="Control" parent="Content" node_paths=PackedStringArray("main_menu_panel")]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -65,7 +65,7 @@ grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
 script = ExtResource("6_ova4h")
-main_menu_panel_path = NodePath("../MainMenuPanel")
+main_menu_panel = NodePath("../MainMenuPanel")
 
 [node name="ComicPage" parent="Content/ComicManager" instance=ExtResource("6_unf1o")]
 layout_mode = 1

--- a/project/src/main/MainMenuPanel.tscn
+++ b/project/src/main/MainMenuPanel.tscn
@@ -58,8 +58,8 @@ visible = false
 [node name="World3Decorations" parent="WorldDecorationHolder" instance=ExtResource("22")]
 visible = false
 
-[node name="CardShadows" parent="." instance=ExtResource("6_w52qk")]
-ParentPanelPath = NodePath("..")
+[node name="CardShadows" parent="." node_paths=PackedStringArray("parent_panel") instance=ExtResource("6_w52qk")]
+parent_panel = NodePath("..")
 
 [node name="MusicControl" type="Control" parent="."]
 custom_minimum_size = Vector2(80, 80)
@@ -93,14 +93,14 @@ offset_right = 462.0
 offset_bottom = 250.0
 mouse_filter = 2
 
-[node name="Card1F" parent="Title" instance=ExtResource("8")]
+[node name="Card1F" parent="Title" node_paths=PackedStringArray("game_state") instance=ExtResource("8")]
 offset_left = 300.545
 offset_top = 52.0022
 offset_right = 380.545
 offset_bottom = 132.002
 card_front_type = 4
 card_front_details = "f1"
-game_state_path = NodePath("../../TitleGameState")
+game_state = NodePath("../../TitleGameState")
 practice = true
 
 [node name="Card1R" parent="Title" instance=ExtResource("8")]
@@ -110,7 +110,7 @@ offset_right = 460.545
 offset_bottom = 132.002
 card_front_type = 4
 card_front_details = "r1"
-game_state_path = NodePath("../../TitleGameState")
+game_state = NodePath("../../TitleGameState")
 practice = true
 
 [node name="Card1O" parent="Title" instance=ExtResource("8")]
@@ -118,7 +118,7 @@ offset_left = 460.545
 offset_top = 52.0022
 offset_right = 540.545
 offset_bottom = 132.002
-game_state_path = NodePath("../../TitleGameState")
+game_state = NodePath("../../TitleGameState")
 practice = true
 
 [node name="Card1G" parent="Title" instance=ExtResource("8")]
@@ -128,7 +128,7 @@ offset_right = 620.545
 offset_bottom = 132.002
 card_front_type = 4
 card_front_details = "g"
-game_state_path = NodePath("../../TitleGameState")
+game_state = NodePath("../../TitleGameState")
 practice = true
 
 [node name="Card2F" parent="Title" instance=ExtResource("8")]
@@ -138,7 +138,7 @@ offset_right = 300.956
 offset_bottom = 214.523
 card_front_type = 4
 card_front_details = "f2"
-game_state_path = NodePath("../../TitleGameState")
+game_state = NodePath("../../TitleGameState")
 practice = true
 
 [node name="Card2I" parent="Title" instance=ExtResource("8")]
@@ -146,7 +146,7 @@ offset_left = 300.956
 offset_top = 134.523
 offset_right = 380.956
 offset_bottom = 214.523
-game_state_path = NodePath("../../TitleGameState")
+game_state = NodePath("../../TitleGameState")
 practice = true
 
 [node name="Card2N" parent="Title" instance=ExtResource("8")]
@@ -156,7 +156,7 @@ offset_right = 460.956
 offset_bottom = 214.523
 card_front_type = 4
 card_front_details = "n"
-game_state_path = NodePath("../../TitleGameState")
+game_state = NodePath("../../TitleGameState")
 practice = true
 
 [node name="Card2D" parent="Title" instance=ExtResource("8")]
@@ -166,7 +166,7 @@ offset_right = 540.956
 offset_bottom = 214.523
 card_front_type = 4
 card_front_details = "d"
-game_state_path = NodePath("../../TitleGameState")
+game_state = NodePath("../../TitleGameState")
 practice = true
 
 [node name="Card2E" parent="Title" instance=ExtResource("8")]
@@ -176,7 +176,7 @@ offset_right = 620.956
 offset_bottom = 214.523
 card_front_type = 4
 card_front_details = "e"
-game_state_path = NodePath("../../TitleGameState")
+game_state = NodePath("../../TitleGameState")
 practice = true
 
 [node name="Card2R" parent="Title" instance=ExtResource("8")]
@@ -186,7 +186,7 @@ offset_right = 700.956
 offset_bottom = 214.523
 card_front_type = 4
 card_front_details = "r2"
-game_state_path = NodePath("../../TitleGameState")
+game_state = NodePath("../../TitleGameState")
 practice = true
 
 [node name="Instructions" type="Control" parent="."]

--- a/project/src/main/card-shadows.gd
+++ b/project/src/main/card-shadows.gd
@@ -5,18 +5,15 @@ extends CanvasGroup
 ## panel.
 
 @export var CardShadowScene: PackedScene
-@export var ParentPanelPath: NodePath
 
 ## The parent panel containing the cards and shadows. The scene tree contains multiple CardShadows instances, but each
 ## only creates shadows for cards in a particular ParentPanel.
-var _parent_panel: Node
+@export var parent_panel: Node
 
 func _ready() -> void:
-	_parent_panel = get_node(ParentPanelPath)
-	
 	## Create shadows for all cards in the scene tree which are children of our parent panel.
 	for card in get_tree().get_nodes_in_group("card_shadow_casters"):
-		if _parent_panel.is_ancestor_of(card):
+		if parent_panel.is_ancestor_of(card):
 			create_shadow(card)
 	
 	Global.card_shadow_caster_added.connect(_on_global_card_shadow_caster_added)
@@ -31,5 +28,5 @@ func create_shadow(card: Node) -> void:
 
 ## Create a shadow for the newly generated card if it is a child of our parent panel.
 func _on_global_card_shadow_caster_added(card: Node) -> void:
-	if _parent_panel.is_ancestor_of(card):
+	if parent_panel.is_ancestor_of(card):
 		create_shadow(card)

--- a/project/src/main/comic-manager.gd
+++ b/project/src/main/comic-manager.gd
@@ -4,9 +4,7 @@ extends Control
 ## These comic interludes are shown on the main menu when the player launches the game or enters a new world. This node
 ## stores a library of which scenes contain which interludes. It loads the appropriate scenes and plays the animations.
 
-@export var main_menu_panel_path: NodePath
-
-@onready var _main_menu_panel: Panel = get_node(main_menu_panel_path)
+@export var main_menu_panel: Panel
 
 ## key: (String) comic id
 ## value: (PackedScene) comic scene for the specified world
@@ -56,7 +54,7 @@ func _on_main_menu_panel_panel_menu_shown() -> void:
 
 ## When the player navigates to a new world for the first time, we show a comic interlude.
 func _on_player_data_world_index_changed() -> void:
-	if _main_menu_panel.visible:
+	if main_menu_panel.visible:
 		# show an intro comic when the player reaches a new chapter
 		show_comic()
 

--- a/project/src/main/comic/World2ComicPage.tscn
+++ b/project/src/main/comic/World2ComicPage.tscn
@@ -3581,12 +3581,12 @@ vframes = 3
 frame = 10
 wiggle_frames = Array[int]([10, 11])
 
-[node name="Conductor" type="AnimationPlayer" parent="."]
+[node name="Conductor" type="AnimationPlayer" parent="." node_paths=PackedStringArray("sfx_player")]
 libraries = {
 "": SubResource("AnimationLibrary_mkq1g")
 }
 script = ExtResource("61_p6166")
-sfx_player_path = NodePath("../SfxPlayer")
+sfx_player = NodePath("../SfxPlayer")
 
 [node name="Timer" type="Timer" parent="Conductor"]
 wait_time = 0.5

--- a/project/src/main/comic/comic-conductor.gd
+++ b/project/src/main/comic/comic-conductor.gd
@@ -4,13 +4,11 @@ extends AnimationPlayer
 ## Threshold where the comic adjusts its visuals to sync back up with the sfx.
 const DESYNC_THRESHOLD_MSEC := 100
 
-@export var sfx_player_path: NodePath
-
 ## Plays a sound effect track.
 ##
 ## Comic sound effects are merged into a single track. This avoids copyright concerns from distributing licensed .wav
 ## files, requires less coding, less audio editing, and less disk space.
-@onready var _sfx_player: AudioStreamPlayer = get_node(sfx_player_path)
+@export var sfx_player: AudioStreamPlayer
 
 ## The offset in seconds for the position of the AudioStreamPlayer's sound effect relative to the AnimationPlayer's
 ## animation.
@@ -61,7 +59,7 @@ func _calculate_sfx_offset() -> void:
 ## 	found.
 func _find_sfx_track(animation: Animation) -> int:
 	# Convert a path like '../SfxPlayer' to be relative to the AnimationPlayer root node like 'SfxPlayer'
-	var sfx_player_animation_path := get_node(root_node).get_path_to(_sfx_player)
+	var sfx_player_animation_path := get_node(root_node).get_path_to(sfx_player)
 	
 	# Locate the SfxPlayer animation track
 	var track_index: int = animation.find_track(sfx_player_animation_path, Animation.TYPE_METHOD)
@@ -95,10 +93,10 @@ func _on_timer_timeout() -> void:
 	if not current_animation == "play":
 		return
 	
-	if not _sfx_player.playing:
+	if not sfx_player.playing:
 		return
 	
-	var desync_amount: float = _sfx_player.get_playback_position() - current_animation_position - _sfx_offset
+	var desync_amount: float = sfx_player.get_playback_position() - current_animation_position - _sfx_offset
 	
 	if abs(desync_amount * 1000) > DESYNC_THRESHOLD_MSEC:
 		advance(desync_amount)

--- a/project/src/main/gameplay-panel.gd
+++ b/project/src/main/gameplay-panel.gd
@@ -98,7 +98,7 @@ func reset() -> void:
 	# load the level rules and update the cards
 	_level_rules = _level_rules_from_id(next_level_id)
 	add_child(_level_rules)
-	_level_rules.level_cards_path = _level_rules.get_path_to(_level_cards)
+	_level_rules.level_cards = _level_cards
 	_level_cards.reset()
 
 

--- a/project/src/main/intermission-panel.gd
+++ b/project/src/main/intermission-panel.gd
@@ -22,8 +22,6 @@ const FROG_DELAYS := [
 	1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
 ]
 
-@export var hand_path: NodePath
-
 var cards: Array = []
 var sharks: Array = []
 var frogs: Array = []
@@ -38,7 +36,7 @@ var next_card_index := 0
 var RunningSharkScene := preload("res://src/main/RunningShark.tscn")
 var RunningFrogScene := preload("res://src/main/RunningFrog.tscn")
 
-@onready var hand: Hand = get_node(hand_path)
+@export var hand: Hand
 
 @onready var _bye_button := $ByeButton
 @onready var _creatures := $Creatures

--- a/project/src/main/level-cards.gd
+++ b/project/src/main/level-cards.gd
@@ -10,7 +10,7 @@ signal shark_found(card)
 
 const CELL_SIZE := Vector2(80, 80)
 
-@export var game_state_path: NodePath
+@export var game_state: GameState
 
 var CardControlScene: PackedScene = preload("res://src/main/CardControl.tscn")
 
@@ -23,8 +23,6 @@ var cards_by_cell_pos := {}
 var cell_positions_by_card := {}
 
 var cell_pos_bounds := Rect2()
-
-@onready var _game_state: GameState = get_node(game_state_path)
 
 func create_card() -> CardControl:
 	var card := CardControlScene.instantiate() as CardControl
@@ -40,7 +38,7 @@ func add_card(card: CardControl, cell_pos: Vector2) -> void:
 	# add the card
 	card.position = cell_pos * CELL_SIZE
 	add_child(card)
-	card.game_state_path = card.get_path_to(_game_state)
+	card.game_state = game_state
 	if cards_by_cell_pos.is_empty():
 		cell_pos_bounds = Rect2(cell_pos, Vector2.ZERO)
 	else:

--- a/project/src/main/levels/frodoku-rules.gd
+++ b/project/src/main/levels/frodoku-rules.gd
@@ -14,8 +14,7 @@ const COL_COUNT := 6
 var _remaining_good_moves := 99
 var _remaining_bad_moves := 99
 
-func refresh_level_cards_path() -> void:
-	super.refresh_level_cards_path()
+func refresh_level_cards() -> void:
 	if not level_cards:
 		return
 	level_cards.connect("before_card_flipped", Callable(self, "_on_level_cards_before_card_flipped"))

--- a/project/src/main/levels/froggo-rules.gd
+++ b/project/src/main/levels/froggo-rules.gd
@@ -66,8 +66,7 @@ var troll_silly_words := [
 ## value: (String) letter to reveal when revealing the word the player clicked
 var _cell_pos_to_revealed_letter := {}
 
-func refresh_level_cards_path() -> void:
-	super.refresh_level_cards_path()
+func refresh_level_cards() -> void:
 	if not level_cards:
 		return
 	level_cards.connect("before_frog_found", Callable(self, "_on_level_cards_before_frog_found"))

--- a/project/src/main/levels/fruit-maze-rules.gd
+++ b/project/src/main/levels/fruit-maze-rules.gd
@@ -90,8 +90,7 @@ var _max_shown_card_count := 99
 var _max_fork_count := 1
 
 
-func refresh_level_cards_path() -> void:
-	super.refresh_level_cards_path()
+func refresh_level_cards() -> void:
 	if not level_cards:
 		return
 	level_cards.connect("before_card_flipped", Callable(self, "_on_level_cards_before_card_flipped"))

--- a/project/src/main/levels/level-rules.gd
+++ b/project/src/main/levels/level-rules.gd
@@ -4,27 +4,19 @@ extends Node
 ##
 ## Subclasses should extend this script to define how cards are arranged and where to find the frog.
 
-@export var level_cards_path: NodePath : set = set_level_cards_path
+@export var level_cards: LevelCards : set = set_level_cards
 
 @export_range(0, 8) var puzzle_difficulty: int = 0 # 0 == very easy, 8 == very hard
-
-var level_cards: LevelCards
-
-func _ready() -> void:
-	refresh_level_cards_path()
-
 
 func add_cards() -> void:
 	pass
 
 
-func set_level_cards_path(new_level_cards_path: NodePath) -> void:
-	level_cards_path = new_level_cards_path
-	refresh_level_cards_path()
-
-
-func refresh_level_cards_path() -> void:
-	if not is_inside_tree() or level_cards_path.is_empty():
-		return
+func set_level_cards(new_level_cards: LevelCards) -> void:
+	level_cards = new_level_cards
 	
-	level_cards = get_node(level_cards_path) if level_cards_path else null
+	refresh_level_cards()
+
+
+func refresh_level_cards() -> void:
+	pass

--- a/project/src/main/levels/maze-rules.gd
+++ b/project/src/main/levels/maze-rules.gd
@@ -51,8 +51,7 @@ var _unblanked_arrow_queue := []
 ## value: (String) card details string for the card's contents before it was blanked
 var _blanked_arrows_to_original := {}
 
-func refresh_level_cards_path() -> void:
-	super.refresh_level_cards_path()
+func refresh_level_cards() -> void:
 	if not level_cards:
 		return
 	level_cards.connect("before_card_flipped", Callable(self, "_on_level_cards_before_card_flipped"))

--- a/project/src/main/levels/pattern-memory-rules.gd
+++ b/project/src/main/levels/pattern-memory-rules.gd
@@ -21,8 +21,7 @@ var _allowed_hidden_lizard_count := 0
 var _shark_chance := 0.5
 var _unhidden_cards := []
 
-func refresh_level_cards_path() -> void:
-	super.refresh_level_cards_path()
+func refresh_level_cards() -> void:
 	if not level_cards:
 		return
 	level_cards.connect("before_card_flipped", Callable(self, "_on_level_cards_before_card_flipped"))

--- a/project/src/main/levels/secret-collect-rules.gd
+++ b/project/src/main/levels/secret-collect-rules.gd
@@ -22,8 +22,7 @@ var _unexamined_secret_cell_positions := {}
 var _remaining_mistakes := 0
 var _lucky_chance := 0.0 # chance of flipping an arrow when placing adjacent to a secret
 
-func refresh_level_cards_path() -> void:
-	super.refresh_level_cards_path()
+func refresh_level_cards() -> void:
 	if not level_cards:
 		return
 	level_cards.connect("before_card_flipped", Callable(self, "_on_level_cards_before_card_flipped"))

--- a/project/src/main/levels/word-find-rules.gd
+++ b/project/src/main/levels/word-find-rules.gd
@@ -15,8 +15,7 @@ var _shark_chance: float = 0.5
 ## value: (bool) true
 var _frog_word_cards := {}
 
-func refresh_level_cards_path() -> void:
-	super.refresh_level_cards_path()
+func refresh_level_cards() -> void:
 	if not level_cards:
 		return
 	level_cards.connect("before_card_flipped", Callable(self, "_on_level_cards_before_card_flipped"))


### PR DESCRIPTION
Godot 4 lets you export a node type directly, handling the nodepath behind the scenes.