### PR TITLE
Fixed 'dance flip logic' for Godot 4

### DIFF
--- a/project/src/main/RunningFrog.tscn
+++ b/project/src/main/RunningFrog.tscn
@@ -51,36 +51,6 @@ tracks/1/keys = {
 "values": [false, false, true, true]
 }
 
-[sub_resource type="Animation" id="20"]
-resource_name = "coy1"
-length = 0.828
-loop_mode = 1
-step = 0.207
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("..:frame")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
-"transitions": PackedFloat32Array(1, 1, 1, 1),
-"update": 1,
-"values": [61, 60, 61, 60]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("..:flip_h")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
-"transitions": PackedFloat32Array(1, 1, 1, 1),
-"update": 1,
-"values": [true, true, false, false]
-}
-
 [sub_resource type="Animation" id="16"]
 resource_name = "coy2"
 length = 0.828
@@ -109,36 +79,6 @@ tracks/1/keys = {
 "transitions": PackedFloat32Array(1, 1, 1, 1),
 "update": 1,
 "values": [false, false, true, true]
-}
-
-[sub_resource type="Animation" id="21"]
-resource_name = "coy2"
-length = 0.828
-loop_mode = 1
-step = 0.207
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("..:frame")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
-"transitions": PackedFloat32Array(1, 1, 1, 1),
-"update": 1,
-"values": [62, 63, 60, 63]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("..:flip_h")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
-"transitions": PackedFloat32Array(1, 1, 1, 1),
-"update": 1,
-"values": [true, true, false, false]
 }
 
 [sub_resource type="Animation" id="8"]
@@ -171,36 +111,6 @@ tracks/1/keys = {
 "values": [false, true, true, false]
 }
 
-[sub_resource type="Animation" id="22"]
-resource_name = "hips1"
-length = 0.828
-loop_mode = 1
-step = 0.207
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("..:frame")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
-"transitions": PackedFloat32Array(1, 1, 1, 1),
-"update": 1,
-"values": [51, 49, 51, 48]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("..:flip_h")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
-"transitions": PackedFloat32Array(1, 1, 1, 1),
-"update": 1,
-"values": [true, false, false, true]
-}
-
 [sub_resource type="Animation" id="12"]
 resource_name = "hips2"
 length = 0.828
@@ -229,36 +139,6 @@ tracks/1/keys = {
 "transitions": PackedFloat32Array(1, 1, 1, 1),
 "update": 1,
 "values": [false, true, true, false]
-}
-
-[sub_resource type="Animation" id="23"]
-resource_name = "hips2"
-length = 0.828
-loop_mode = 1
-step = 0.207
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("..:frame")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
-"transitions": PackedFloat32Array(1, 1, 1, 1),
-"update": 1,
-"values": [50, 48, 50, 49]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("..:flip_h")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
-"transitions": PackedFloat32Array(1, 1, 1, 1),
-"update": 1,
-"values": [true, false, false, true]
 }
 
 [sub_resource type="Animation" id="17"]
@@ -291,36 +171,6 @@ tracks/1/keys = {
 "values": [false, true, true, false]
 }
 
-[sub_resource type="Animation" id="24"]
-resource_name = "nip1"
-length = 0.828
-loop_mode = 1
-step = 0.207
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("..:frame")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
-"transitions": PackedFloat32Array(1, 1, 1, 1),
-"update": 1,
-"values": [52, 55, 52, 55]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("..:flip_h")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
-"transitions": PackedFloat32Array(1, 1, 1, 1),
-"update": 1,
-"values": [true, false, false, true]
-}
-
 [sub_resource type="Animation" id="18"]
 resource_name = "nip2"
 length = 0.828
@@ -351,36 +201,6 @@ tracks/1/keys = {
 "values": [true, false, true, false]
 }
 
-[sub_resource type="Animation" id="25"]
-resource_name = "nip2"
-length = 0.828
-loop_mode = 1
-step = 0.207
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("..:frame")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
-"transitions": PackedFloat32Array(1, 1, 1, 1),
-"update": 1,
-"values": [53, 55, 55, 53]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("..:flip_h")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
-"transitions": PackedFloat32Array(1, 1, 1, 1),
-"update": 1,
-"values": [false, true, false, true]
-}
-
 [sub_resource type="Animation" id="19"]
 resource_name = "nip3"
 length = 1.656
@@ -409,36 +229,6 @@ tracks/1/keys = {
 "transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1),
 "update": 1,
 "values": [true, false, true, false, false, true, false, true]
-}
-
-[sub_resource type="Animation" id="26"]
-resource_name = "nip3"
-length = 1.656
-loop_mode = 1
-step = 0.207
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("..:frame")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.207, 0.414, 0.621, 0.828, 1.035, 1.242, 1.449),
-"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1),
-"update": 1,
-"values": [54, 55, 52, 55, 54, 55, 52, 55]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("..:flip_h")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.207, 0.414, 0.621, 0.828, 1.035, 1.242, 1.449),
-"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1),
-"update": 1,
-"values": [false, true, false, true, true, false, true, false]
 }
 
 [sub_resource type="Animation" id="13"]
@@ -490,59 +280,6 @@ tracks/2/keys = {
 "method": &"shimmy"
 }, {
 "args": [Vector2(15, 0)],
-"method": &"shimmy"
-}]
-}
-
-[sub_resource type="Animation" id="27"]
-resource_name = "shuffle1"
-length = 0.828
-loop_mode = 1
-step = 0.207
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("..:frame")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
-"transitions": PackedFloat32Array(1, 1, 1, 1),
-"update": 1,
-"values": [59, 56, 57, 56]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("..:flip_h")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.621),
-"transitions": PackedFloat32Array(1, 1),
-"update": 1,
-"values": [true, true]
-}
-tracks/2/type = "method"
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/path = NodePath("..")
-tracks/2/interp = 1
-tracks/2/loop_wrap = true
-tracks/2/keys = {
-"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
-"transitions": PackedFloat32Array(1, 1, 1, 1),
-"values": [{
-"args": [Vector2(-15, 0)],
-"method": &"shimmy"
-}, {
-"args": [Vector2(-15, 0)],
-"method": &"shimmy"
-}, {
-"args": [Vector2(-15, 0)],
-"method": &"shimmy"
-}, {
-"args": [Vector2(-15, 0)],
 "method": &"shimmy"
 }]
 }
@@ -600,7 +337,270 @@ tracks/2/keys = {
 }]
 }
 
-[sub_resource type="Animation" id="28"]
+[sub_resource type="Animation" id="Animation_2xnjg"]
+resource_name = "coy1"
+length = 0.828
+loop_mode = 1
+step = 0.207
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("..:frame")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 1,
+"values": [61, 60, 61, 60]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("..:flip_h")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 1,
+"values": [true, true, false, false]
+}
+
+[sub_resource type="Animation" id="Animation_nxoa5"]
+resource_name = "coy2"
+length = 0.828
+loop_mode = 1
+step = 0.207
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("..:frame")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 1,
+"values": [62, 63, 60, 63]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("..:flip_h")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 1,
+"values": [true, true, false, false]
+}
+
+[sub_resource type="Animation" id="Animation_rlc50"]
+resource_name = "hips1"
+length = 0.828
+loop_mode = 1
+step = 0.207
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("..:frame")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 1,
+"values": [51, 49, 51, 48]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("..:flip_h")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 1,
+"values": [true, false, false, true]
+}
+
+[sub_resource type="Animation" id="Animation_1p625"]
+resource_name = "hips2"
+length = 0.828
+loop_mode = 1
+step = 0.207
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("..:frame")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 1,
+"values": [50, 48, 50, 49]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("..:flip_h")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 1,
+"values": [true, false, false, true]
+}
+
+[sub_resource type="Animation" id="Animation_11di6"]
+resource_name = "nip1"
+length = 0.828
+loop_mode = 1
+step = 0.207
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("..:frame")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 1,
+"values": [52, 55, 52, 55]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("..:flip_h")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 1,
+"values": [true, false, false, true]
+}
+
+[sub_resource type="Animation" id="Animation_h2g27"]
+resource_name = "nip2"
+length = 0.828
+loop_mode = 1
+step = 0.207
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("..:frame")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 1,
+"values": [53, 55, 55, 53]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("..:flip_h")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 1,
+"values": [false, true, false, true]
+}
+
+[sub_resource type="Animation" id="Animation_6c45e"]
+resource_name = "nip3"
+length = 1.656
+loop_mode = 1
+step = 0.207
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("..:frame")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.207, 0.414, 0.621, 0.828, 1.035, 1.242, 1.449),
+"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1),
+"update": 1,
+"values": [54, 55, 52, 55, 54, 55, 52, 55]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("..:flip_h")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.207, 0.414, 0.621, 0.828, 1.035, 1.242, 1.449),
+"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1),
+"update": 1,
+"values": [false, true, false, true, true, false, true, false]
+}
+
+[sub_resource type="Animation" id="Animation_w66jl"]
+resource_name = "shuffle1"
+length = 0.828
+loop_mode = 1
+step = 0.207
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("..:frame")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 1,
+"values": [59, 56, 57, 56]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("..:flip_h")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.621),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [true, true]
+}
+tracks/2/type = "method"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("..")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0, 0.207, 0.414, 0.621),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"values": [{
+"args": [Vector2(-15, 0)],
+"method": &"shimmy"
+}, {
+"args": [Vector2(-15, 0)],
+"method": &"shimmy"
+}, {
+"args": [Vector2(-15, 0)],
+"method": &"shimmy"
+}, {
+"args": [Vector2(-15, 0)],
+"method": &"shimmy"
+}]
+}
+
+[sub_resource type="Animation" id="Animation_626is"]
 resource_name = "shuffle2"
 length = 0.828
 loop_mode = 1
@@ -657,23 +657,23 @@ tracks/2/keys = {
 _data = {
 "RESET": SubResource("11"),
 "coy1": SubResource("15"),
-"coy1_flip": SubResource("20"),
+"coy1_flip": SubResource("Animation_2xnjg"),
 "coy2": SubResource("16"),
-"coy2_flip": SubResource("21"),
+"coy2_flip": SubResource("Animation_nxoa5"),
 "hips1": SubResource("8"),
-"hips1_flip": SubResource("22"),
+"hips1_flip": SubResource("Animation_rlc50"),
 "hips2": SubResource("12"),
-"hips2_flip": SubResource("23"),
+"hips2_flip": SubResource("Animation_1p625"),
 "nip1": SubResource("17"),
-"nip1_flip": SubResource("24"),
+"nip1_flip": SubResource("Animation_11di6"),
 "nip2": SubResource("18"),
-"nip2_flip": SubResource("25"),
+"nip2_flip": SubResource("Animation_h2g27"),
 "nip3": SubResource("19"),
-"nip3_flip": SubResource("26"),
+"nip3_flip": SubResource("Animation_6c45e"),
 "shuffle1": SubResource("13"),
-"shuffle1_flip": SubResource("27"),
+"shuffle1_flip": SubResource("Animation_w66jl"),
 "shuffle2": SubResource("14"),
-"shuffle2_flip": SubResource("28")
+"shuffle2_flip": SubResource("Animation_626is")
 }
 
 [sub_resource type="Animation" id="10"]

--- a/project/src/main/dance-animations.gd
+++ b/project/src/main/dance-animations.gd
@@ -67,7 +67,7 @@ func _save_dance_names() -> void:
 		
 		dance_set[_dance_name_from_animation_name(animation_name)] = true
 	
-	dance_names = dance_set.keys()
+	dance_names.assign(dance_set.keys())
 
 
 ## Populates animation_names_by_dance_name with animations from our animation list.
@@ -126,10 +126,10 @@ func _flip_animations() -> void:
 	for animation_name in get_animation_list():
 		if animation_name in NON_DANCE_ANIMS:
 			continue
-			
+
 		if animation_name.ends_with("_flip"):
-			remove_animation_library(animation_name)
-	
+			get_animation_library("").remove_animation(animation_name)
+
 	for old_animation_name in get_animation_list():
 		_flip_animation(old_animation_name)
 


### PR DESCRIPTION
When transitioning from Godot 3 to Godot 4, I incorrectly added a remove_animation_library() call instead of getting the animation library and removing the appropriate animation. There was also an array cast error.