### PR TITLE
RunningShark offset. RunningFrog reset frame.

### DIFF
--- a/project/src/main/RunningFrog.tscn
+++ b/project/src/main/RunningFrog.tscn
@@ -18,7 +18,7 @@ tracks/0/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [50]
+"values": [1]
 }
 
 [sub_resource type="Animation" id="15"]

--- a/project/src/main/RunningShark.tscn
+++ b/project/src/main/RunningShark.tscn
@@ -91,9 +91,13 @@ _data = {
 "run-fed": SubResource("2")
 }
 
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_x611c"]
+size = Vector2(120, 60)
+
 [node name="RunningShark" type="Sprite2D"]
 scale = Vector2(0.467, 0.467)
 texture = ExtResource("1")
+offset = Vector2(0, -80)
 hframes = 4
 vframes = 2
 frame = 4

--- a/project/src/main/running-shark.gd
+++ b/project/src/main/running-shark.gd
@@ -21,7 +21,7 @@ const MAX_AGILITY := 4.0
 const PINCER_DISTANCE := 150.0
 
 ## where the shark has to stand to count as 'catching' the hand
-const HAND_CATCH_OFFSET := Vector2(28, 20)
+const HAND_CATCH_OFFSET := Vector2(28, 60)
 
 ## the hand to chase
 var hand: Hand


### PR DESCRIPTION
Aligned RunningShark offset so their x/y coordinate aligns with their feet. This allows y-sort to work as expected, and also allows for some cleaner collision logic in an upcoming commit.