### PR TITLE
Change renderer to 'forward'; it is no longer slow

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -51,5 +51,4 @@ mouse=false
 
 [rendering]
 
-renderer/rendering_method="gl_compatibility"
 environment/defaults/default_clear_color=Color(0.580392, 0.717647, 0.847059, 1)


### PR DESCRIPTION
The 'Forward+' renderer used to take about 10 seconds to launch, but they've seemingly improved its performance. It sometimes takes 10 seconds to launch but after the first launch, it's fast.