### PR TITLE
Alphabetize autoload singletons. Narrowing conversion warning.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -18,11 +18,11 @@ config/version="1.21"
 
 [autoload]
 
-Global="*res://src/main/global.gd"
 CardArrangements="*res://src/main/card-arrangements.gd"
-PlayerData="*res://src/main/player-data.gd"
-MusicPlayer="*res://src/main/MusicPlayer.tscn"
 FrogArrangements="*res://src/main/frog-arrangements.gd"
+Global="*res://src/main/global.gd"
+MusicPlayer="*res://src/main/MusicPlayer.tscn"
+PlayerData="*res://src/main/player-data.gd"
 SfxDeconflicter="*res://src/main/SfxDeconflicter.tscn"
 
 [debug]

--- a/project/src/main/beach-ball-tweak.gd
+++ b/project/src/main/beach-ball-tweak.gd
@@ -23,7 +23,7 @@ func _input(event: InputEvent) -> void:
 ## Returns: The closest ball to the mouse, or 'null' if no balls are close enough to be clicked.
 func _find_clicked_ball() -> BeachBall:
 	var clicked_ball: BeachBall
-	var clicked_ball_distance := 999999
+	var clicked_ball_distance := 999999.0
 	
 	# find the ball closest to the mouse
 	var local_mouse_position := panel.obstacles.get_local_mouse_position()


### PR DESCRIPTION
Changed clicked_ball_distance to a float to avoid a narrowing conversion warning.