### PR TITLE
Changed version number generation to '1.21'

### DIFF
--- a/generate-export-presets.sh
+++ b/generate-export-presets.sh
@@ -15,15 +15,12 @@
 
 if [ "$1" ]
 then
-  # uncomment 'tool' lines to allow editing
   version="$1"
 else
 # Calculate version string
-  yy=$(date +%Y)
-  mmdd=$(date +%m%d)
-  mmdd=$(echo "$mmdd" | sed 's/^0*//')
-  version=$(((yy - 2020) * 2000 + mmdd))
-  version=$(printf 0.%04d $version)
+  seconds=$(date +%s)
+  version=$((seconds / 2500000 - 658))
+  version=$(printf 1.%02d $version)
 fi
 
 echo "version=$version"


### PR DESCRIPTION
Instead of versions like '0.7501', our version number generation logic now generates numbers like '1.21'. The old system was inherited from Turbo Fat.