### PR TITLE
Workaround for circular reference error in IntermissionPanel.

### DIFF
--- a/project/src/main/intermission-panel.gd
+++ b/project/src/main/intermission-panel.gd
@@ -24,8 +24,10 @@ const FROG_DELAYS := [
 
 ## key: (int) world index
 ## value: (PackedScene) IntermissionTweak scene which modifies the intermission in some ways
-var _tweak_scenes_by_world_index := {
-	1: preload("res://src/main/BeachBallTweak.tscn"),
+@onready var _tweak_scenes_by_world_index := {
+	# Workaround for Godot #72453 (https://github.com/godotengine/godot/issues/74253). These resources cannot be
+	# preloaded because they introduce a cyclic reference which causes errors in the editor.
+	1: load("res://src/main/BeachBallTweak.tscn"),
 }
 
 var cards: Array = []


### PR DESCRIPTION
IntermissionPanel and BeachBallTweak reference each other, because SceneTreeTweaks describe how to modify an IntermissionPanel and IntermissionPanel includes a list of all scene tree tweaks. This circular reference makes it so that BeachBallTweak (and all other tweaks) can not be opened in the editor, because of Godot #74253 (https://github.com/godotengine/godot/issues/74253)

I've resolved the circular reference by having these scenes initialized at runtime with a 'load' command, rather than when the scene is loaded with a 'preload' command.