### PR TITLE
CardControl is now a tool script.

### DIFF
--- a/project/src/main/CardControl.tscn
+++ b/project/src/main/CardControl.tscn
@@ -13,9 +13,13 @@ offset_bottom = 80.0
 script = ExtResource("3")
 
 [node name="CardBack" parent="." instance=ExtResource("2")]
+frame = 6
+wiggle_frames = Array[int]([6, 7])
 
 [node name="CardFront" parent="." instance=ExtResource("2")]
 visible = false
+frame = 4
+wiggle_frames = Array[int]([4, 5])
 
 [node name="CheerTimer" type="Timer" parent="."]
 wait_time = 0.5

--- a/project/src/main/card-control.gd
+++ b/project/src/main/card-control.gd
@@ -1,3 +1,4 @@
+@tool
 class_name CardControl
 extends Control
 ## Shows a card. These cards can turn over to reveal frogs, sharks, fruit, or other surprises.
@@ -140,6 +141,8 @@ const LIZARD_COUNT := 32
 @export var card_front_details: String : set = set_card_front_details
 
 @export var game_state: GameState
+
+## 'true' if the frog/shark doesn't count, maybe because it was on the main menu
 @export var practice := false
 
 @export var shown_face := CardFace.BACK : set = set_shown_face


### PR DESCRIPTION
This is useful for things like dynamically generating titles within the editor. Now we can preview that the code works without launching the game, because the cards will change in the editor.