### PR TITLE
Bug: IntermissionPanel.reset() enabled tweaks when invisible.

### DIFF
--- a/project/src/main/intermission-panel.gd
+++ b/project/src/main/intermission-panel.gd
@@ -84,7 +84,8 @@ func reset() -> void:
 	
 	if has_tweak():
 		remove_tweak()
-	add_tweak()
+	if visible:
+		add_tweak()
 
 
 func add_level_result(found_card: CardControl) -> void:


### PR DESCRIPTION
Fixed a bug where IntermissionPanel.reset() enabled tweaks when invisible. This meant that after finishing a beach level, you could click around and invisible beach ball noises would play. It was kind of fun in a way but still glitchy.