### PR TITLE
Fix editor 'PlayerData.world_index' error

### DIFF
--- a/project/src/main/main-menu-title.gd
+++ b/project/src/main/main-menu-title.gd
@@ -33,7 +33,8 @@ var _mystery_cards: Array = []
 func _ready() -> void:
 	PlayerData.connect("world_index_changed", Callable(self, "_on_player_data_world_index_changed"))
 	
-	text = titles_by_world_index.get(PlayerData.world_index, DEFAULT_TITLE)
+	if not Engine.is_editor_hint():
+		text = titles_by_world_index.get(PlayerData.world_index, DEFAULT_TITLE)
 
 
 func _exit_tree() -> void:


### PR DESCRIPTION
The main menu title script is a tool script, so it was trying to access 'PlayerData.world_index' in the editor.