### PR TITLE
Bug: Music played for a fraction of a second when 'off'

### DIFF
--- a/project/src/main/player-data.gd
+++ b/project/src/main/player-data.gd
@@ -102,11 +102,11 @@ func load_player_data() -> void:
 	if save_json.has("music_preference") and int(save_json["music_preference"]) > MusicPreference.OFF:
 		save_json["music_preference"] = MusicPreference.RANDOM
 	
-	if save_json.has("world"):
-		set_world_index(int(save_json["world"]))
 	if save_json.has("music_preference"):
 		# handle old music preference; used to go from 0-7
 		set_music_preference(int(save_json["music_preference"]))
+	if save_json.has("world"):
+		set_world_index(int(save_json["world"]))
 	if save_json.has("frog_count"):
 		frog_count = int(save_json["frog_count"])
 	if save_json.has("shark_count"):


### PR DESCRIPTION
When the music was configured to 'off', it still played briefly when the game started up because the world index was set first (triggering music) before the music preference was set (setting it to off.)

This wouldn't be noticable, except that the music fades out so you can actually hear it for 0.1 seconds or so.