### PR TITLE
Avoid randomizing comic letter frames in the editor

### DIFF
--- a/project/src/demo/ComicLetterDemo.tscn
+++ b/project/src/demo/ComicLetterDemo.tscn
@@ -22,8 +22,9 @@ script = ExtResource("1_3fo1s")
 [node name="Letter1" parent="." instance=ExtResource("1_ranxm")]
 material = SubResource("ShaderMaterial_ptj1e")
 position = Vector2(462, 300)
-frame = 15
+frame = 14
 
 [node name="Letter2" parent="." instance=ExtResource("1_ranxm")]
 material = SubResource("ShaderMaterial_cbdgp")
 position = Vector2(562, 300)
+frame = 14

--- a/project/src/main/comic/comic-letter.gd
+++ b/project/src/main/comic/comic-letter.gd
@@ -72,7 +72,12 @@ func _refresh_text() -> void:
 		return
 	
 	var frame_indexes: Array = FRAME_INDEXES_BY_LETTER.get(text, EMPTY_FRAME_INDEXES)
-	frame = Utils.rand_value(frame_indexes)
+	
+	if Engine.is_editor_hint():
+		# avoid randomizing frames in the editor, it causes unnecessary churn in our .tscn files
+		frame = frame_indexes[0]
+	else:
+		frame = Utils.rand_value(frame_indexes)
 
 
 ## Launches the tween which makes the sprite slowly bob up and down.

--- a/project/src/main/wiggle-sprite.gd
+++ b/project/src/main/wiggle-sprite.gd
@@ -15,6 +15,7 @@ func reset_wiggle() -> void:
 
 func assign_wiggle_frame() -> void:
 	if Engine.is_editor_hint():
+		# avoid randomizing frames in the editor, it causes unnecessary churn in our .tscn files
 		frame = wiggle_frames[0] if wiggle_frames else 0
 		return
 	


### PR DESCRIPTION
This causes unnecessary churn in our .tscn files, and more specifically was causing ComicLetterDemo to change every time it was saved