### PR TITLE
Fixed 'static called on instance' warnings.

### DIFF
--- a/project/src/main/card-control.gd
+++ b/project/src/main/card-control.gd
@@ -336,6 +336,9 @@ func _refresh_card_face(card_sprite: Sprite2D, card_type: int, card_details: Str
 			var mystery_index: int
 			if MYSTERY_INDEXES_BY_DETAILS.has(card_details):
 				var mystery_indexes: Array = MYSTERY_INDEXES_BY_DETAILS[card_details]
+				# Workaround for Godot #69282 (https://github.com/godotengine/godot/issues/69282); calling static function
+				# from within a class generates a warning
+				@warning_ignore("static_called_on_instance")
 				mystery_index = _mostly_rand_value(mystery_indexes)
 			else:
 				mystery_index = card_randi % MYSTERY_COUNT
@@ -345,6 +348,9 @@ func _refresh_card_face(card_sprite: Sprite2D, card_type: int, card_details: Str
 			var letter_index: int
 			if LETTER_INDEXES_BY_DETAILS.has(card_details):
 				var letter_indexes: Array = LETTER_INDEXES_BY_DETAILS[card_details]
+				# Workaround for Godot #69282 (https://github.com/godotengine/godot/issues/69282); calling static function
+				# from within a class generates a warning
+				@warning_ignore("static_called_on_instance")
 				letter_index = _mostly_rand_value(letter_indexes)
 			else:
 				# We never want random letters in a level. If this is happening, something is wrong.
@@ -356,6 +362,9 @@ func _refresh_card_face(card_sprite: Sprite2D, card_type: int, card_details: Str
 			var arrow_index: int
 			if ARROW_INDEXES_BY_DETAILS.has(card_details):
 				var arrow_indexes: Array = ARROW_INDEXES_BY_DETAILS[card_details]
+				# Workaround for Godot #69282 (https://github.com/godotengine/godot/issues/69282); calling static function
+				# from within a class generates a warning
+				@warning_ignore("static_called_on_instance")
 				arrow_index = _mostly_rand_value(arrow_indexes)
 			else:
 				# We never want random arrows in a level. If this is happening, something is wrong.
@@ -367,6 +376,9 @@ func _refresh_card_face(card_sprite: Sprite2D, card_type: int, card_details: Str
 			var arrow_index: int
 			if HEX_ARROW_INDEXES_BY_DETAILS.has(card_details):
 				var arrow_indexes: Array = HEX_ARROW_INDEXES_BY_DETAILS[card_details]
+				# Workaround for Godot #69282 (https://github.com/godotengine/godot/issues/69282); calling static function
+				# from within a class generates a warning
+				@warning_ignore("static_called_on_instance")
 				arrow_index = _mostly_rand_value(arrow_indexes)
 			else:
 				# We never want random arrows in a level. If this is happening, something is wrong.

--- a/project/src/main/player-data.gd
+++ b/project/src/main/player-data.gd
@@ -113,12 +113,7 @@ func load_player_data() -> void:
 		shark_count = int(save_json["shark_count"])
 	if save_json.has("missions_cleared"):
 		var new_missions_cleared: Dictionary = save_json["missions_cleared"]
-		
-		# Workaround for Godot #69282 (https://github.com/godotengine/godot/issues/9499); calling static function from
-		# within a class generates a warning
-		@warning_ignore("static_called_on_instance")
 		Utils.convert_dict_floats_to_ints(new_missions_cleared)
-		
 		missions_cleared = new_missions_cleared
 	if save_json.has("frog_dance_count"):
 		frog_dance_count = int(save_json["frog_dance_count"])


### PR DESCRIPTION
Removed unnnecessary 'static called on instance' warning; this method is now calling a static function correctly.