### PR TITLE
Fixed comic letter interpolation mode warning.

### DIFF
--- a/project/src/main/comic/ComicLetter.tscn
+++ b/project/src/main/comic/ComicLetter.tscn
@@ -28,7 +28,7 @@ tracks/1/type = "value"
 tracks/1/imported = false
 tracks/1/enabled = true
 tracks/1/path = NodePath(".:rotation")
-tracks/1/interp = 1
+tracks/1/interp = 4
 tracks/1/loop_wrap = true
 tracks/1/keys = {
 "times": PackedFloat32Array(0),
@@ -101,7 +101,7 @@ texture = ExtResource("1_7t5e1")
 offset = Vector2(0, 1.536)
 hframes = 4
 vframes = 4
-frame = 15
+frame = 14
 script = ExtResource("3_jlo34")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]


### PR DESCRIPTION
The warning occurred because the reset method used a different interpolation method.