### PR TITLE
Refactor: Node.connect -> Signal.connect

### DIFF
--- a/project/src/demo/background-demo-preset.gd
+++ b/project/src/demo/background-demo-preset.gd
@@ -10,7 +10,7 @@ const MAX_WORLD_INDEX := 99
 @onready var _label := $VBoxContainer/HBoxContainer/Label
 
 func _ready() -> void:
-	PlayerData.connect("world_index_changed", Callable(self, "_on_player_data_world_index_changed"))
+	PlayerData.world_index_changed.connect(_on_player_data_world_index_changed)
 	_refresh_label_text()
 
 

--- a/project/src/main/background.gd
+++ b/project/src/main/background.gd
@@ -41,7 +41,7 @@ var texture_color: Color
 @onready var _color_rect := $ColorRect
 
 func _ready() -> void:
-	PlayerData.connect("world_index_changed", Callable(self, "_on_player_data_world_index_changed"))
+	PlayerData.world_index_changed.connect(_on_player_data_world_index_changed)
 	
 	var new_texture_color := _random_texture_color_for_world()
 	change_specific(new_texture_color, true)

--- a/project/src/main/card-control.gd
+++ b/project/src/main/card-control.gd
@@ -427,7 +427,7 @@ func _flip_card() -> void:
 	
 	show_front()
 	game_state.flip_timer.start()
-	game_state.flip_timer.connect("timeout", Callable(self, "_on_flip_timer_timeout"))
+	game_state.flip_timer.timeout.connect(_on_flip_timer_timeout)
 
 
 func _on_flip_timer_timeout() -> void:

--- a/project/src/main/comic-manager.gd
+++ b/project/src/main/comic-manager.gd
@@ -17,7 +17,7 @@ extends Control
 var _main_menu_show_count := 0
 
 func _ready() -> void:
-	PlayerData.connect("world_index_changed", Callable(self, "_on_player_data_world_index_changed"))
+	PlayerData.world_index_changed.connect(_on_player_data_world_index_changed)
 
 
 ## Shows the comic interlude for the current world.

--- a/project/src/main/frog-chase-behavior.gd
+++ b/project/src/main/frog-chase-behavior.gd
@@ -41,7 +41,7 @@ func set_hand(new_hand: Hand) -> void:
 	hand = new_hand
 	
 	if hand:
-		hand.connect("hug_finished", Callable(self, "_on_hand_hug_finished"))
+		hand.hug_finished.connect(_on_hand_hug_finished)
 
 
 func start_behavior(new_frog: Node) -> void:

--- a/project/src/main/frog-dance-behavior.gd
+++ b/project/src/main/frog-dance-behavior.gd
@@ -78,7 +78,7 @@ func start_behavior(new_frog: Node) -> void:
 	if is_lead_frog():
 		for next_frog in frogs:
 			_frogs_running_to_dance[next_frog] = true
-			next_frog.connect("reached_dance_target", Callable(self, "_on_running_frog_reached_dance_target").bind(next_frog))
+			next_frog.reached_dance_target.connect(_on_running_frog_reached_dance_target.bind(next_frog))
 	
 	set_state(DanceState.RUN_TO_DANCE)
 

--- a/project/src/main/frog-give-ribbon-behavior.gd
+++ b/project/src/main/frog-give-ribbon-behavior.gd
@@ -37,7 +37,7 @@ func set_hand(new_hand: Hand) -> void:
 	hand = new_hand
 	
 	if hand:
-		hand.connect("hug_finished", Callable(self, "_on_hand_hug_finished"))
+		hand.hug_finished.connect(_on_hand_hug_finished)
 
 
 func start_behavior(new_frog: Node) -> void:

--- a/project/src/main/intermission-panel.gd
+++ b/project/src/main/intermission-panel.gd
@@ -54,7 +54,7 @@ var RunningFrogScene := preload("res://src/main/RunningFrog.tscn")
 @onready var _shark_spawn_timer := $SharkSpawnTimer
 
 func _ready() -> void:
-	hand.connect("hug_finished", Callable(self, "_on_hand_hug_finished"))
+	hand.hug_finished.connect(_on_hand_hug_finished)
 
 
 func is_full() -> bool:
@@ -129,7 +129,7 @@ func start_frog_dance(frog_count: int) -> void:
 		var new_frog := _spawn_frog()
 		dance_frogs.append(new_frog)
 	
-	frogs[0].connect("finished_dance", Callable(self, "_on_running_frog_finished_dance"))
+	frogs[0].finished_dance.connect(_on_running_frog_finished_dance)
 	
 	var arrangement := FrogArrangements.get_arrangement(frog_count)
 	
@@ -149,7 +149,7 @@ func start_frog_ribbon() -> void:
 	if hand.ribbon:
 		_bye_button.visible = true
 	else:
-		frogs[0].connect("finished_give_ribbon", Callable(self, "_on_running_frog_finished_give_ribbon"))
+		frogs[0].finished_give_ribbon.connect(_on_running_frog_finished_give_ribbon)
 
 
 func has_tweak() -> bool:

--- a/project/src/main/level-buttons.gd
+++ b/project/src/main/level-buttons.gd
@@ -22,7 +22,7 @@ signal level_pressed(level_index)
 func _ready() -> void:
 	var main_menu_panels: Array = get_tree().get_nodes_in_group("main_menu_panels")
 	if main_menu_panels.size() == 1:
-		main_menu_panels[0].connect("menu_shown", Callable(self, "_on_main_menu_panel_menu_shown"))
+		main_menu_panels[0].menu_shown.connect(_on_main_menu_panel_menu_shown)
 	else:
 		push_warning("Unexpected main menu panel count: %s" % [main_menu_panels.size()])
 

--- a/project/src/main/level-cards.gd
+++ b/project/src/main/level-cards.gd
@@ -26,11 +26,11 @@ var cell_pos_bounds := Rect2()
 
 func create_card() -> CardControl:
 	var card := CardControlScene.instantiate() as CardControl
-	card.connect("before_card_flipped", Callable(self, "_on_card_control_before_card_flipped").bind(card))
-	card.connect("frog_found", Callable(self, "_on_card_control_frog_found").bind(card))
-	card.connect("shark_found", Callable(self, "_on_card_control_shark_found").bind(card))
-	card.connect("before_frog_found", Callable(self, "_on_card_control_before_frog_found").bind(card))
-	card.connect("before_shark_found", Callable(self, "_on_card_control_before_shark_found").bind(card))
+	card.before_card_flipped.connect(_on_card_control_before_card_flipped.bind(card))
+	card.frog_found.connect(_on_card_control_frog_found.bind(card))
+	card.shark_found.connect(_on_card_control_shark_found.bind(card))
+	card.before_frog_found.connect(_on_card_control_before_frog_found.bind(card))
+	card.before_shark_found.connect(_on_card_control_before_shark_found.bind(card))
 	return card
 
 

--- a/project/src/main/levels/frodoku-rules.gd
+++ b/project/src/main/levels/frodoku-rules.gd
@@ -30,8 +30,8 @@ var _remaining_bad_moves := 99
 func refresh_level_cards() -> void:
 	if not level_cards:
 		return
-	level_cards.connect("before_card_flipped", Callable(self, "_on_level_cards_before_card_flipped"))
-	level_cards.connect("before_shark_found", Callable(self, "_on_level_cards_before_shark_found"))
+	level_cards.before_card_flipped.connect(_on_level_cards_before_card_flipped)
+	level_cards.before_shark_found.connect(_on_level_cards_before_shark_found)
 
 
 func add_cards() -> void:

--- a/project/src/main/levels/froggo-rules.gd
+++ b/project/src/main/levels/froggo-rules.gd
@@ -69,8 +69,8 @@ var _cell_pos_to_revealed_letter := {}
 func refresh_level_cards() -> void:
 	if not level_cards:
 		return
-	level_cards.connect("before_frog_found", Callable(self, "_on_level_cards_before_frog_found"))
-	level_cards.connect("before_shark_found", Callable(self, "_on_level_cards_before_shark_found"))
+	level_cards.before_frog_found.connect(_on_level_cards_before_frog_found)
+	level_cards.before_shark_found.connect(_on_level_cards_before_shark_found)
 
 
 func add_cards() -> void:

--- a/project/src/main/levels/fruit-maze-rules.gd
+++ b/project/src/main/levels/fruit-maze-rules.gd
@@ -93,8 +93,8 @@ var _max_fork_count := 1
 func refresh_level_cards() -> void:
 	if not level_cards:
 		return
-	level_cards.connect("before_card_flipped", Callable(self, "_on_level_cards_before_card_flipped"))
-	level_cards.connect("before_shark_found", Callable(self, "_on_level_cards_before_shark_found"))
+	level_cards.before_card_flipped.connect(_on_level_cards_before_card_flipped)
+	level_cards.before_shark_found.connect(_on_level_cards_before_shark_found)
 
 
 func add_cards() -> void:

--- a/project/src/main/levels/maze-rules.gd
+++ b/project/src/main/levels/maze-rules.gd
@@ -54,8 +54,8 @@ var _blanked_arrows_to_original := {}
 func refresh_level_cards() -> void:
 	if not level_cards:
 		return
-	level_cards.connect("before_card_flipped", Callable(self, "_on_level_cards_before_card_flipped"))
-	level_cards.connect("before_shark_found", Callable(self, "_on_level_cards_before_shark_found"))
+	level_cards.before_card_flipped.connect(_on_level_cards_before_card_flipped)
+	level_cards.before_shark_found.connect(_on_level_cards_before_shark_found)
 
 
 func add_cards() -> void:

--- a/project/src/main/levels/pattern-memory-rules.gd
+++ b/project/src/main/levels/pattern-memory-rules.gd
@@ -24,8 +24,8 @@ var _unhidden_cards := []
 func refresh_level_cards() -> void:
 	if not level_cards:
 		return
-	level_cards.connect("before_card_flipped", Callable(self, "_on_level_cards_before_card_flipped"))
-	level_cards.connect("before_shark_found", Callable(self, "_on_level_cards_before_shark_found"))
+	level_cards.before_card_flipped.connect(_on_level_cards_before_card_flipped)
+	level_cards.before_shark_found.connect(_on_level_cards_before_shark_found)
 
 
 func add_cards() -> void:

--- a/project/src/main/levels/secret-collect-rules.gd
+++ b/project/src/main/levels/secret-collect-rules.gd
@@ -25,8 +25,8 @@ var _lucky_chance := 0.0 # chance of flipping an arrow when placing adjacent to 
 func refresh_level_cards() -> void:
 	if not level_cards:
 		return
-	level_cards.connect("before_card_flipped", Callable(self, "_on_level_cards_before_card_flipped"))
-	level_cards.connect("before_shark_found", Callable(self, "_on_level_cards_before_shark_found"))
+	level_cards.before_card_flipped.connect(_on_level_cards_before_card_flipped)
+	level_cards.before_shark_found.connect(_on_level_cards_before_shark_found)
 
 
 func add_cards() -> void:

--- a/project/src/main/levels/word-find-rules.gd
+++ b/project/src/main/levels/word-find-rules.gd
@@ -18,8 +18,8 @@ var _frog_word_cards := {}
 func refresh_level_cards() -> void:
 	if not level_cards:
 		return
-	level_cards.connect("before_card_flipped", Callable(self, "_on_level_cards_before_card_flipped"))
-	level_cards.connect("before_shark_found", Callable(self, "_on_level_cards_before_shark_found"))
+	level_cards.before_card_flipped.connect(_on_level_cards_before_card_flipped)
+	level_cards.before_shark_found.connect(_on_level_cards_before_shark_found)
 
 
 func add_cards() -> void:

--- a/project/src/main/main-menu-panel.gd
+++ b/project/src/main/main-menu-panel.gd
@@ -35,10 +35,10 @@ func _connect_title_card_listeners() -> void:
 			# Avoid connecting redundant listeners for cards which already existed. This happens for mystery cards.
 			continue
 		
-		card.connect("before_frog_found", Callable(self, "_on_card_control_before_frog_found").bind(card))
-		card.connect("frog_found", Callable(self, "_on_card_control_frog_found").bind(card))
-		card.connect("before_shark_found", Callable(self, "_on_card_control_before_shark_found").bind(card))
-		card.connect("shark_found", Callable(self, "_on_card_control_shark_found").bind(card))
+		card.before_frog_found.connect(_on_card_control_before_frog_found.bind(card))
+		card.frog_found.connect(_on_card_control_frog_found.bind(card))
+		card.before_shark_found.connect(_on_card_control_before_shark_found.bind(card))
+		card.shark_found.connect(_on_card_control_shark_found.bind(card))
 
 
 func _on_card_control_before_frog_found(card: CardControl) -> void:

--- a/project/src/main/main-menu-title.gd
+++ b/project/src/main/main-menu-title.gd
@@ -31,7 +31,7 @@ var titles_by_world_index := {
 var _mystery_cards: Array = []
 
 func _ready() -> void:
-	PlayerData.connect("world_index_changed", Callable(self, "_on_player_data_world_index_changed"))
+	PlayerData.world_index_changed.connect(_on_player_data_world_index_changed)
 	
 	if not Engine.is_editor_hint():
 		text = titles_by_world_index.get(PlayerData.world_index, DEFAULT_TITLE)

--- a/project/src/main/menu-state.gd
+++ b/project/src/main/menu-state.gd
@@ -45,7 +45,7 @@ func _show_intermission_panel(card: CardControl) -> void:
 		if intermission_panel.is_full():
 			_play_ending()
 		else:
-			_start_timer(3.0).connect("timeout", Callable(self, "_on_timer_timeout_end_intermission"))
+			_start_timer(3.0).timeout.connect(_on_timer_timeout_end_intermission)
 
 
 ## Creates and starts a one-shot timer.
@@ -76,7 +76,7 @@ func _add_timer(wait_time: float) -> Timer:
 	var timer := Timer.new()
 	timer.one_shot = true
 	timer.wait_time = wait_time
-	timer.connect("timeout", Callable(self, "_on_timer_timeout_queue_free").bind(timer))
+	timer.timeout.connect(_on_timer_timeout_queue_free.bind(timer))
 	_timers.add_child(timer)
 	return timer
 
@@ -130,7 +130,7 @@ func _play_ending() -> void:
 ## After a delay, spawns frogs which hug the cursor.
 func _schedule_frog_hug_ending(huggable_fingers: int, new_max_frogs: int) -> void:
 	MusicPlayer.fade_out(4.0)
-	_start_timer(3.0).connect("timeout", _on_timer_timeout_play_frog_hug_ending.bind(huggable_fingers, new_max_frogs))
+	_start_timer(3.0).timeout.connect(_on_timer_timeout_play_frog_hug_ending.bind(huggable_fingers, new_max_frogs))
 
 
 ## Spawns frogs which hug the cursor.
@@ -178,7 +178,7 @@ func _on_gameplay_panel_frog_found(card: CardControl) -> void:
 
 func _on_hand_finger_bitten() -> void:
 	if hand.biteable_fingers == 0:
-		_start_timer(4.0).connect("timeout", Callable(self, "_on_timer_timeout_end_intermission"))
+		_start_timer(4.0).timeout.connect(_on_timer_timeout_end_intermission)
 
 
 func _on_main_menu_panel_frog_found(_card: CardControl) -> void:

--- a/project/src/main/music-control.gd
+++ b/project/src/main/music-control.gd
@@ -13,7 +13,7 @@ const WIGGLE_FRAMES_BY_MUSIC_PREFERENCE := {
 
 func _ready() -> void:
 	_refresh_sprite()
-	PlayerData.connect("music_preference_changed", Callable(self, "_on_player_data_music_preference_changed"))
+	PlayerData.music_preference_changed.connect(_on_player_data_music_preference_changed)
 
 
 func _gui_input(event: InputEvent) -> void:

--- a/project/src/main/music-player.gd
+++ b/project/src/main/music-player.gd
@@ -64,8 +64,8 @@ var _tweens_by_song := {}
 @onready var _ending_song := $HugFromAFrog
 
 func _ready() -> void:
-	PlayerData.connect("music_preference_changed", Callable(self, "_on_player_data_music_preference_changed"))
-	PlayerData.connect("world_index_changed", Callable(self, "_on_player_data_world_index_changed"))
+	PlayerData.music_preference_changed.connect(_on_player_data_music_preference_changed)
+	PlayerData.world_index_changed.connect(_on_player_data_world_index_changed)
 
 
 func play_preferred_song() -> void:

--- a/project/src/main/ui/menu/level-button-holder.gd
+++ b/project/src/main/ui/menu/level-button-holder.gd
@@ -2,7 +2,7 @@ extends Control
 
 func _ready() -> void:
 	_refresh_world_index()
-	PlayerData.connect("world_index_changed", Callable(self, "_on_player_data_world_index_changed"))
+	PlayerData.world_index_changed.connect(_on_player_data_world_index_changed)
 
 
 ## Ensure exactly one set of world buttons is visible.

--- a/project/src/main/world-decoration-holder.gd
+++ b/project/src/main/world-decoration-holder.gd
@@ -3,7 +3,7 @@ extends Control
 
 func _ready() -> void:
 	_refresh_world_index()
-	PlayerData.connect("world_index_changed", Callable(self, "_on_player_data_world_index_changed"))
+	PlayerData.world_index_changed.connect(_on_player_data_world_index_changed)
 
 
 ## Ensure exactly one set of world decorations is visible.


### PR DESCRIPTION
This syntax is shorter and prevents us from misspelling signals.