### PR TITLE
Music is no longer played in random demos.

### DIFF
--- a/project/src/main/menu-state.gd
+++ b/project/src/main/menu-state.gd
@@ -21,6 +21,8 @@ func _ready() -> void:
 	main_menu_panel.show_menu()
 	
 	MusicPlayer.play_preferred_song()
+	PlayerData.music_preference_changed.connect(_on_player_data_music_preference_changed)
+	PlayerData.world_index_changed.connect(_on_player_data_world_index_changed)
 
 
 func _hide_panels() -> void:
@@ -218,3 +220,11 @@ func _on_cheat_code_detector_cheat_detected(cheat: String, detector: CheatCodeDe
 			if main_menu_panel.visible:
 				CardArrangements.one_frog_cheat = !CardArrangements.one_frog_cheat
 				detector.play_cheat_sound(CardArrangements.one_frog_cheat)
+
+
+func _on_player_data_music_preference_changed() -> void:
+	MusicPlayer.play_preferred_song()
+
+
+func _on_player_data_world_index_changed() -> void:
+	MusicPlayer.play_preferred_song()

--- a/project/src/main/music-player.gd
+++ b/project/src/main/music-player.gd
@@ -63,11 +63,6 @@ var _tweens_by_song := {}
 ## AudioStreamPlayer which plays when the player finds enough frogs to finish a mission.
 @onready var _ending_song := $HugFromAFrog
 
-func _ready() -> void:
-	PlayerData.music_preference_changed.connect(_on_player_data_music_preference_changed)
-	PlayerData.world_index_changed.connect(_on_player_data_world_index_changed)
-
-
 func play_preferred_song() -> void:
 	var world_songs: Array = _songs_by_world_index.get(PlayerData.world_index, _default_songs)
 	match PlayerData.music_preference:
@@ -207,14 +202,6 @@ func _fade(song: AudioStreamPlayer, new_volume_db: float, duration: float) -> vo
 	if is_equal_approx(new_volume_db, MIN_VOLUME):
 		## stop playback after music fades out
 		fade_tween.tween_callback(_current_song.stop)
-
-
-func _on_player_data_music_preference_changed() -> void:
-	play_preferred_song()
-
-
-func _on_player_data_world_index_changed() -> void:
-	play_preferred_song()
 
 
 func _on_frog_dance_finished() -> void:


### PR DESCRIPTION
Before, MusicPlayer was a singleton which automatically started playing music when PlayerData loaded the player's music preference. Now, MainMenu is responsible for playing music, so it doesn't happen in random demos like 'BackgroundDemo'.