### PR TITLE
Refactor: Improve super_panic_duration constant use

### DIFF
--- a/project/src/main/frog-chase-behavior.gd
+++ b/project/src/main/frog-chase-behavior.gd
@@ -83,7 +83,7 @@ func _panic() -> void:
 func _on_panic_timer_timeout() -> void:
 	if hand.hugged_fingers >= hand.huggable_fingers and randf() < 0.5:
 		# oh no, we can't hug the hand! continue panicking!
-		_panic_timer.start(randf_range(SUPER_PANIC_DURATION, 5.0))
+		_panic_timer.start(SUPER_PANIC_DURATION * randf_range(0.8, 1.2))
 		_frog.velocity = Vector2.RIGHT.rotated(randf_range(0, PI * 2)) * _frog.run_speed
 	else:
 		_chase()

--- a/project/src/main/frog-give-ribbon-behavior.gd
+++ b/project/src/main/frog-give-ribbon-behavior.gd
@@ -78,7 +78,7 @@ func _panic() -> void:
 func _on_panic_timer_timeout() -> void:
 	if hand.ribbon and randf() < 0.5:
 		# oh no, we can't give away our ribbon! continue panicking!
-		_panic_timer.start(randf_range(SUPER_PANIC_DURATION, 5.0))
+		_panic_timer.start(SUPER_PANIC_DURATION * randf_range(0.8, 1.2))
 		_frog.velocity = Vector2.RIGHT.rotated(randf_range(0, PI * 2)) * _frog.run_speed
 	else:
 		_chase()


### PR DESCRIPTION
The old code was using SUPER_PANIC_DURATION in a weird way where it only made sense if it was a value slightly under 5.0, defeating the purpose of a constant.

The new code mirrors similar code in the frog-chase-behavior script, and allows SUPER_PANIC_DURATION to be adjusted freely.