### PR TITLE
Fixed World2ComicPage panel 5 modulate

### DIFF
--- a/project/src/main/comic/World2ComicPage.tscn
+++ b/project/src/main/comic/World2ComicPage.tscn
@@ -616,7 +616,7 @@ tracks/1/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Color(1, 1, 1, 0)]
+"values": [Color(1, 1, 1, 1)]
 }
 tracks/2/type = "value"
 tracks/2/imported = false
@@ -3040,10 +3040,8 @@ grow_horizontal = 2
 grow_vertical = 2
 scale = Vector2(0.35, 0.35)
 script = ExtResource("4_ruepq")
-panel_modulate = Color(1, 1, 1, 0)
 
 [node name="Contents" type="ColorRect" parent="ComicPanel03"]
-self_modulate = Color(1, 1, 1, 0)
 clip_children = 2
 layout_mode = 1
 anchors_preset = 15
@@ -3090,7 +3088,6 @@ hframes = 2
 vframes = 2
 
 [node name="Frame" type="Sprite2D" parent="ComicPanel03"]
-self_modulate = Color(1, 1, 1, 0)
 position = Vector2(225, 217.5)
 texture = ExtResource("25_l00h5")
 


### PR DESCRIPTION
Panel 5's 'panel_modulate' property was being reset improperly, which made the 'show_all' functionality not actually show it.