### PR TITLE
Changed/added enum comments

### DIFF
--- a/project/src/main/card-control.gd
+++ b/project/src/main/card-control.gd
@@ -164,7 +164,7 @@ const LIZARD_COUNT := 32
 	set(new_shown_face):
 		shown_face = new_shown_face
 		_refresh_shown_face()
-	
+
 var _frog_sounds := [
 	preload("res://assets/main/sfx/frog-voice-0.wav"),
 	preload("res://assets/main/sfx/frog-voice-1.wav"),

--- a/project/src/main/frog-dance-behavior.gd
+++ b/project/src/main/frog-dance-behavior.gd
@@ -3,11 +3,11 @@ extends CreatureBehavior
 
 ## The different states a frog progresses through before and after a dance.
 enum DanceState {
-	NONE,
-	RUN_TO_DANCE,
-	WAIT_TO_DANCE,
-	DANCE,
-	RUN_FROM_DANCE,
+	NONE, ## The frog is not dancing or running.
+	RUN_TO_DANCE, ## The frog is running to the dance target.
+	WAIT_TO_DANCE, ## The frog is waiting at the dance target.
+	DANCE, ## The frog is dancing.
+	RUN_FROM_DANCE, ## The frog is running from the dance target.
 }
 
 ## Threshold where the frog adjusts their animation to sync back up with the music.

--- a/project/src/main/hand-sprite.gd
+++ b/project/src/main/hand-sprite.gd
@@ -6,11 +6,11 @@ extends Sprite2D
 ## This script only handles animating the main hand sprite.
 
 enum State {
-	NONE,
-	THREE_FINGERS,
-	TWO_FINGERS,
-	ONE_FINGER,
-	NO_FINGERS,
+	NONE, ## The hand is not visible
+	THREE_FINGERS, ## The hand has three fingers left
+	TWO_FINGERS, ## The hand has two fingers left
+	ONE_FINGER, ## The hand has one finger left
+	NO_FINGERS, ## The hand has no fingers left
 }
 
 var state: int = State.ONE_FINGER : set = set_state

--- a/project/src/main/player-data.gd
+++ b/project/src/main/player-data.gd
@@ -8,17 +8,17 @@ signal world_index_changed
 signal music_preference_changed
 
 enum MissionResult {
-	NONE, # The player has not finished this mission yet
-	SHARK, # The player finished the mission by getting eaten
-	FROG, # The player finished the mission by finding enough frogs
+	NONE, ## The player has not finished this mission yet
+	SHARK, ## The player finished the mission by getting eaten
+	FROG, ## The player finished the mission by finding enough frogs
 }
 
 enum MusicPreference {
-	RANDOM,
-	MUSIC_1, # first song in each area; 'long song'
-	MUSIC_2, # second song in each area; 'short song'
-	MUSIC_3, # third song in each area; 'instrumental song'
-	OFF,
+	RANDOM, ## Random song from each area
+	MUSIC_1, ## First song in each area; 'long song'
+	MUSIC_2, ## Second song in each area; 'short song'
+	MUSIC_3, ## Third song in each area; 'instrumental song'
+	OFF, ## No music
 }
 
 const DATA_FILENAME := "user://player-data.json"


### PR DESCRIPTION
Godot can now show editor comments for enums in some cases. I've changed these comments to adapt to their conventions with '##' instead of '#'.