### PR TITLE
Refactor: Lambdas, disconnect/is_connected syntax

### DIFF
--- a/project/src/main/card-control.gd
+++ b/project/src/main/card-control.gd
@@ -424,7 +424,7 @@ func _flip_card() -> void:
 
 
 func _on_flip_timer_timeout() -> void:
-	game_state.flip_timer.disconnect("timeout", Callable(self, "_on_flip_timer_timeout"))
+	game_state.flip_timer.timeout.disconnect(_on_flip_timer_timeout)
 	match card_front_type:
 		CardType.FROG:
 			if practice:

--- a/project/src/main/frog-chase-behavior.gd
+++ b/project/src/main/frog-chase-behavior.gd
@@ -27,7 +27,7 @@ var friend: Sprite2D
 var hand: Hand:
 	set(new_hand):
 		if hand:
-			hand.disconnect("hug_finished", Callable(self, "_on_hand_hug_finished"))
+			hand.hug_finished.disconnect(_on_hand_hug_finished)
 		hand = new_hand
 		if hand:
 			hand.hug_finished.connect(_on_hand_hug_finished)

--- a/project/src/main/frog-dance-behavior.gd
+++ b/project/src/main/frog-dance-behavior.gd
@@ -115,8 +115,8 @@ func stop_behavior(_new_frog: Node) -> void:
 	# disconnect signals
 	if is_lead_frog():
 		for next_frog in frogs:
-			if next_frog.is_connected("reached_dance_target", Callable(self, "_on_running_frog_reached_dance_target")):
-				next_frog.disconnect("reached_dance_target", self, "_on_running_frog_reached_dance_target", [next_frog])
+			if next_frog.reached_dance_target.is_connected(_on_running_frog_reached_dance_target):
+				next_frog.reached_dance_target.disconnect(_on_running_frog_reached_dance_target.bind([next_frog]))
 	
 	frogs = []
 	dance_target = Vector2.ZERO
@@ -229,7 +229,7 @@ func _on_running_frog_reached_dance_target(other_frog: RunningFrog) -> void:
 	if not is_lead_frog():
 		return
 	
-	other_frog.disconnect("reached_dance_target", Callable(self, "_on_running_frog_reached_dance_target"))
+	other_frog.reached_dance_target.disconnect(_on_running_frog_reached_dance_target)
 	_frogs_running_to_dance.erase(other_frog)
 	if _frogs_running_to_dance.is_empty():
 		# all frogs have reached their dance targets, we can start dancing

--- a/project/src/main/frog-give-ribbon-behavior.gd
+++ b/project/src/main/frog-give-ribbon-behavior.gd
@@ -23,7 +23,7 @@ const HAND_CATCH_OFFSET := Vector2(28, 57)
 var hand: Hand:
 	set(new_hand):
 		if hand:
-			hand.disconnect("hug_finished", Callable(self, "_on_hand_hug_finished"))
+			hand.hug_finished.disconnect(_on_hand_hug_finished)
 		hand = new_hand
 		if hand:
 			hand.hug_finished.connect(_on_hand_hug_finished)

--- a/project/src/main/intermission-panel.gd
+++ b/project/src/main/intermission-panel.gd
@@ -220,7 +220,8 @@ func _random_spawn_point(away_from_hand: bool) -> Vector2:
 	]
 	
 	if away_from_hand:
-		spawn_points.sort_custom(Callable(self, "_sort_by_distance_from_hand"))
+		spawn_points.sort_custom(func(a: Vector2, b: Vector2) -> bool:
+			return hand.global_position.distance_to(a) > hand.global_position.distance_to(b))
 	else:
 		spawn_points.shuffle()
 	
@@ -235,10 +236,6 @@ func _chase(frog: RunningFrog) -> void:
 ## Puts a frog into 'dance mode'.
 func _dance(frog: RunningFrog, dance_frogs: Array, dance_target: Vector2) -> void:
 	frog.dance(dance_frogs, dance_target)
-
-
-func _sort_by_distance_from_hand(a: Vector2, b: Vector2) -> bool:
-	return hand.global_position.distance_to(a) > hand.global_position.distance_to(b)
 
 
 func _on_shark_spawn_timer_timeout() -> void:

--- a/project/src/main/levels/frodoku-rules.gd
+++ b/project/src/main/levels/frodoku-rules.gd
@@ -14,9 +14,15 @@ const COL_COUNT := 6
 ## Methods used to check whether two cells conflict. Cells conflict if they are in the same row, the same column, or
 ## the same 3x2 region.
 var _compare_methods := [
-		Callable(self, "_compare_by_row"),
-		Callable(self, "_compare_by_column"),
-		Callable(self, "_compare_by_region"),
+		## Returns 'true' if the two specified cells are in the same row.
+		func(pos_1: Vector2, pos_2: Vector2) -> bool:
+			return pos_1.y == pos_2.y,
+		## Returns 'true' if the two specified cells are in the same column.
+		func(pos_1: Vector2, pos_2: Vector2) -> bool:
+			return pos_1.x == pos_2.x,
+		## Returns 'true' if the two specified cells are in the same 3x2 region.
+		func(pos_1: Vector2, pos_2: Vector2) -> bool:
+			return _region(pos_1) == _region(pos_2),
 	]
 
 ## The number of valid cards the player must click before finding a frog. (The player will always find a frog if five
@@ -229,21 +235,6 @@ func _possible_mistake_count() -> int:
 		if _conflicting_lizard(card):
 			result += 1
 	return result
-
-
-## Returns 'true' if the two specified cells are in the same column.
-func _compare_by_column(pos_1: Vector2, pos_2: Vector2) -> bool:
-	return pos_1.x == pos_2.x
-
-
-## Returns 'true' if the two specified cells are in the same row.
-func _compare_by_row(pos_1: Vector2, pos_2: Vector2) -> bool:
-	return pos_1.y == pos_2.y
-
-
-## Returns 'true' if the two specified cells are in the same 3x2 region.
-func _compare_by_region(pos_1: Vector2, pos_2: Vector2) -> bool:
-	return _region(pos_1) == _region(pos_2)
 
 
 ## Returns an int corresponding to the cell's 3x2 region.

--- a/project/src/main/main-menu-panel.gd
+++ b/project/src/main/main-menu-panel.gd
@@ -31,7 +31,7 @@ func _connect_title_card_listeners() -> void:
 		return
 	
 	for card in _title.get_children():
-		if card.is_connected("before_frog_found", Callable(self, "_on_card_control_before_frog_found").bind(card)):
+		if card.before_frog_found.is_connected(_on_card_control_before_frog_found):
 			# Avoid connecting redundant listeners for cards which already existed. This happens for mystery cards.
 			continue
 		


### PR DESCRIPTION
Used lambdas in more places, such as sort_custom parameters or Frodoku's comparison functions.

Changed disconnect/is_connectecd syntax to use method names instead of Callables. Callables are a relic of Godot 3.x and the new syntax is more concise.