### PR TITLE
Fixed bad signal method capitalization. Added delint check.

### DIFF
--- a/delint.sh
+++ b/delint.sh
@@ -110,6 +110,16 @@ then
   echo "$RESULT"
 fi
 
+# signal functions with bad capitalization
+RESULT=$(grep -R -n "func _on_[A-Z]" --include="*.gd" project/src \
+  )
+if [ -n "$RESULT" ]
+then
+  echo ""
+  echo "Signal functions with bad capitalization:"
+  echo "$RESULT"
+fi
+
 # temporary files
 RESULT=$(find project -name "*.TMP" -o -name "*.gd~" -o -name "*.tmp")
 if [ -n "$RESULT" ]

--- a/project/src/demo/BeachBallDemo.tscn
+++ b/project/src/demo/BeachBallDemo.tscn
@@ -19,4 +19,4 @@ offset_right = -50.0
 offset_bottom = -50.0
 theme_override_styles/panel = ExtResource("2_vp4l0")
 
-[connection signal="resized" from="Panel" to="." method="_on_Panel_resized"]
+[connection signal="resized" from="Panel" to="." method="_on_panel_resized"]

--- a/project/src/demo/beach-ball-demo.gd
+++ b/project/src/demo/beach-ball-demo.gd
@@ -73,5 +73,5 @@ func _refresh_bounce_rect() -> void:
 		ball.bounce_rect = Rect2(Vector2.ZERO, _panel.size)
 
 
-func _on_Panel_resized() -> void:
+func _on_panel_resized() -> void:
 	_refresh_bounce_rect()

--- a/project/src/main/BeachBall.tscn
+++ b/project/src/main/BeachBall.tscn
@@ -33,5 +33,5 @@ shape = SubResource("RectangleShape2D_hdnlp")
 stream = ExtResource("3_lowhv")
 bus = &"Sfx"
 
-[connection signal="area_entered" from="Area2D" to="." method="_on_Area2D_area_entered"]
-[connection signal="timeout" from="RedrawTimer" to="." method="_on_RedrawTimer_timeout"]
+[connection signal="area_entered" from="Area2D" to="." method="_on_area_2d_area_entered"]
+[connection signal="timeout" from="RedrawTimer" to="." method="_on_redraw_timer_timeout"]

--- a/project/src/main/beach-ball.gd
+++ b/project/src/main/beach-ball.gd
@@ -185,12 +185,12 @@ func _play_bounce_sfx(velocity_differential: float = 1000.0) -> void:
 ## When our redraw timer times out, we refresh the visuals based on the ball's position.
 ##
 ## This will happen if the ball is moving slowly or not at all.
-func _on_RedrawTimer_timeout() -> void:
+func _on_redraw_timer_timeout() -> void:
 	_refresh_visuals()
 
 
 ## When a frog or shark enters our collision area, we bounce into the air.
-func _on_Area2D_area_entered(_area: Area2D) -> void:
+func _on_area_2d_area_entered(_area: Area2D) -> void:
 	if physics_position.z < 50:
 		# Don't do a full bounce, more of a half bounce.
 		bounce(randf_range(0.65, 0.75))


### PR DESCRIPTION
In Godot 3.x we used '_on_FooBar()' capitalization. In Godot 4.x we prefer '_on_foo_bar()'.