### PR TITLE
Refactor: Demos use unique Godot 4.x 'unique names'.

### DIFF
--- a/project/src/demo/BackgroundDemo.tscn
+++ b/project/src/demo/BackgroundDemo.tscn
@@ -1,9 +1,9 @@
 [gd_scene load_steps=5 format=3 uid="uid://sn44oyirw2l7"]
 
 [ext_resource type="PackedScene" uid="uid://uo0hbda0ic10" path="res://src/main/Background.tscn" id="1"]
-[ext_resource type="PackedScene" uid="uid://btv2b51s8uefp" path="res://src/demo/BackgroundDemoCustomTab.tscn" id="3_q417h"]
+[ext_resource type="PackedScene" path="res://src/demo/BackgroundDemoCustomTab.tscn" id="3_yt2y2"]
+[ext_resource type="PackedScene" path="res://src/demo/BackgroundDemoPresetTab.tscn" id="4_dk6re"]
 [ext_resource type="Theme" uid="uid://cnmvsalviybmg" path="res://src/main/ui/menu/theme/h4.theme" id="4_ikoou"]
-[ext_resource type="PackedScene" uid="uid://b662wm85gb2ml" path="res://src/demo/BackgroundDemoPresetTab.tscn" id="4_xi02f"]
 
 [node name="BackgroundDemo" type="Node"]
 
@@ -20,14 +20,12 @@ offset_bottom = -50.0
 grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("4_ikoou")
-current_tab = 1
 
-[node name="Custom" parent="TabContainer" node_paths=PackedStringArray("background") instance=ExtResource("3_q417h")]
-visible = false
+[node name="Custom" parent="TabContainer" node_paths=PackedStringArray("background") instance=ExtResource("3_yt2y2")]
 layout_mode = 2
 background = NodePath("../../Background")
 
-[node name="Preset" parent="TabContainer" node_paths=PackedStringArray("background") instance=ExtResource("4_xi02f")]
-visible = true
+[node name="Preset" parent="TabContainer" node_paths=PackedStringArray("background") instance=ExtResource("4_dk6re")]
+visible = false
 layout_mode = 2
 background = NodePath("../../Background")

--- a/project/src/demo/BackgroundDemoCustomTab.tscn
+++ b/project/src/demo/BackgroundDemoCustomTab.tscn
@@ -1,48 +1,51 @@
-[gd_scene load_steps=3 format=3 uid="uid://btv2b51s8uefp"]
+[gd_scene load_steps=3 format=3 uid="uid://oymla7s4a4pn"]
 
-[ext_resource type="Script" path="res://src/demo/background-demo-custom-tab.gd" id="1_ikmqs"]
-[ext_resource type="PackedScene" uid="uid://cn8xedg15n2hn" path="res://src/demo/BackgroundDemoPickerRow.tscn" id="2_m2kij"]
+[ext_resource type="Script" path="res://src/demo/background-demo-custom-tab.gd" id="1_vyxk3"]
+[ext_resource type="PackedScene" uid="uid://cn8xedg15n2hn" path="res://src/demo/BackgroundDemoPickerRow.tscn" id="2_vw3mi"]
 
-[node name="Custom" type="MarginContainer" node_paths=PackedStringArray("background")]
+[node name="Custom" type="MarginContainer"]
 theme_override_constants/margin_left = 25
 theme_override_constants/margin_top = 25
 theme_override_constants/margin_right = 25
 theme_override_constants/margin_bottom = 25
-script = ExtResource("1_ikmqs")
-PickerRowScene = ExtResource("2_m2kij")
-background = NodePath("")
+script = ExtResource("1_vyxk3")
+PickerRowScene = ExtResource("2_vw3mi")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
+[node name="PickerContainer" type="VBoxContainer" parent="."]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(300, 0)
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 0
 
-[node name="TextEdit" type="TextEdit" parent="VBoxContainer"]
+[node name="TextEdit" type="TextEdit" parent="PickerContainer"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 100)
 layout_mode = 2
 text = "[\"ffffff\", \"eeeeee\"]"
 wrap_mode = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="PickerContainer"]
 layout_mode = 2
 
-[node name="AddButton" type="Button" parent="VBoxContainer/HBoxContainer"]
+[node name="AddButton" type="Button" parent="PickerContainer/HBoxContainer"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(40, 0)
 layout_mode = 2
 text = "+"
 
-[node name="RemoveButton" type="Button" parent="VBoxContainer/HBoxContainer"]
+[node name="RemoveButton" type="Button" parent="PickerContainer/HBoxContainer"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(40, 0)
 layout_mode = 2
 text = "-"
 
-[node name="HSeparator" type="HSeparator" parent="VBoxContainer"]
+[node name="HSeparator" type="HSeparator" parent="PickerContainer"]
 layout_mode = 2
 
-[node name="PickerRow" parent="VBoxContainer" instance=ExtResource("2_m2kij")]
+[node name="PickerRow" parent="PickerContainer" instance=ExtResource("2_vw3mi")]
 layout_mode = 2
 
-[connection signal="text_changed" from="VBoxContainer/TextEdit" to="." method="_on_text_edit_text_changed"]
-[connection signal="pressed" from="VBoxContainer/HBoxContainer/AddButton" to="." method="_on_add_button_pressed"]
-[connection signal="pressed" from="VBoxContainer/HBoxContainer/RemoveButton" to="." method="_on_remove_button_pressed"]
+[connection signal="text_changed" from="PickerContainer/TextEdit" to="." method="_on_text_edit_text_changed"]
+[connection signal="pressed" from="PickerContainer/HBoxContainer/AddButton" to="." method="_on_add_button_pressed"]
+[connection signal="pressed" from="PickerContainer/HBoxContainer/RemoveButton" to="." method="_on_remove_button_pressed"]

--- a/project/src/demo/BackgroundDemoPickerRow.tscn
+++ b/project/src/demo/BackgroundDemoPickerRow.tscn
@@ -8,6 +8,7 @@ alignment = 1
 script = ExtResource("1_8avel")
 
 [node name="ColorPickerButton" type="ColorPickerButton" parent="."]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 theme = ExtResource("2_8m33r")

--- a/project/src/demo/BackgroundDemoPresetTab.tscn
+++ b/project/src/demo/BackgroundDemoPresetTab.tscn
@@ -1,23 +1,21 @@
-[gd_scene load_steps=3 format=3 uid="uid://b662wm85gb2ml"]
+[gd_scene load_steps=3 format=3 uid="uid://cukg5duqtr381"]
 
-[ext_resource type="Script" path="res://src/demo/background-demo-preset-tab.gd" id="1_xs50c"]
-[ext_resource type="Theme" uid="uid://cnmvsalviybmg" path="res://src/main/ui/menu/theme/h4.theme" id="2_lxax8"]
+[ext_resource type="Script" path="res://src/demo/background-demo-preset-tab.gd" id="1_oahcl"]
+[ext_resource type="Theme" uid="uid://cnmvsalviybmg" path="res://src/main/ui/menu/theme/h4.theme" id="2_sv4ti"]
 
-[node name="Preset" type="MarginContainer" node_paths=PackedStringArray("background")]
-visible = false
+[node name="Preset" type="MarginContainer"]
 theme_override_constants/margin_left = 25
 theme_override_constants/margin_top = 25
 theme_override_constants/margin_right = 25
 theme_override_constants/margin_bottom = 25
-script = ExtResource("1_xs50c")
-background = NodePath("")
+script = ExtResource("1_oahcl")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 custom_minimum_size = Vector2(300, 0)
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 0
-theme = ExtResource("2_lxax8")
+theme = ExtResource("2_sv4ti")
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
@@ -28,7 +26,8 @@ custom_minimum_size = Vector2(30, 0)
 layout_mode = 2
 text = "<"
 
-[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer"]
+[node name="WorldLabel" type="Label" parent="VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 text = "World 1"

--- a/project/src/demo/BeachBallDemo.tscn
+++ b/project/src/demo/BeachBallDemo.tscn
@@ -9,6 +9,7 @@ script = ExtResource("1_j633c")
 BeachBallScene = ExtResource("1_0dii3")
 
 [node name="Panel" type="Panel" parent="."]
+unique_name_in_owner = true
 y_sort_enabled = true
 anchors_preset = 15
 anchor_right = 1.0

--- a/project/src/demo/ComicLetterDemo.tscn
+++ b/project/src/demo/ComicLetterDemo.tscn
@@ -20,9 +20,11 @@ shader_parameter/modulate = Color(1, 1, 1, 1)
 script = ExtResource("1_3fo1s")
 
 [node name="Letter1" parent="." instance=ExtResource("1_ranxm")]
+unique_name_in_owner = true
 material = SubResource("ShaderMaterial_ptj1e")
 position = Vector2(462, 300)
 
 [node name="Letter2" parent="." instance=ExtResource("1_ranxm")]
+unique_name_in_owner = true
 material = SubResource("ShaderMaterial_cbdgp")
 position = Vector2(562, 300)

--- a/project/src/demo/ComicPageDemo.tscn
+++ b/project/src/demo/ComicPageDemo.tscn
@@ -6,7 +6,8 @@
 [node name="Node" type="Node"]
 script = ExtResource("1_ad1qj")
 
-[node name="Label" type="Label" parent="."]
+[node name="ResourcePathLabel" type="Label" parent="."]
+unique_name_in_owner = true
 anchors_preset = 10
 anchor_right = 1.0
 offset_bottom = 30.0

--- a/project/src/demo/HandDemo.tscn
+++ b/project/src/demo/HandDemo.tscn
@@ -7,3 +7,4 @@
 script = ExtResource("1")
 
 [node name="Hand" parent="." instance=ExtResource("2")]
+unique_name_in_owner = true

--- a/project/src/demo/IntermissionPanelDemo.tscn
+++ b/project/src/demo/IntermissionPanelDemo.tscn
@@ -8,6 +8,7 @@
 script = ExtResource("2")
 
 [node name="IntermissionPanel" parent="." node_paths=PackedStringArray("hand") instance=ExtResource("1")]
+unique_name_in_owner = true
 offset_left = 50.0
 offset_top = 50.0
 offset_right = -50.0
@@ -15,3 +16,4 @@ offset_bottom = -50.0
 hand = NodePath("../Hand")
 
 [node name="Hand" parent="." instance=ExtResource("3")]
+unique_name_in_owner = true

--- a/project/src/demo/LevelRulesDemo.tscn
+++ b/project/src/demo/LevelRulesDemo.tscn
@@ -13,6 +13,7 @@ script = ExtResource("3")
 LevelRulesScene = ExtResource("2_xtps5")
 
 [node name="GameplayPanel" type="Panel" parent="."]
+unique_name_in_owner = true
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -40,6 +41,7 @@ script = ExtResource("4")
 game_state = NodePath("../GameState")
 
 [node name="DifficultyLabel" type="Label" parent="."]
+unique_name_in_owner = true
 modulate = Color(1, 1, 1, 0.313726)
 offset_left = 5.0
 offset_top = 5.0

--- a/project/src/demo/background-demo-custom-tab.gd
+++ b/project/src/demo/background-demo-custom-tab.gd
@@ -7,11 +7,6 @@ extends Node
 @export var PickerRowScene: PackedScene
 @export var background: Background
 
-@onready var _text_edit: TextEdit = $VBoxContainer/TextEdit
-@onready var _picker_container: Container = $VBoxContainer
-@onready var _add_button: Button = $VBoxContainer/HBoxContainer/AddButton
-@onready var _remove_button: Button = $VBoxContainer/HBoxContainer/RemoveButton
-
 var _suppress_listeners := false
 
 func _ready() -> void:
@@ -39,7 +34,7 @@ func _refresh_text_from_color_array(colors: Array) -> void:
 	var color_strings := []
 	for color in colors:
 		color_strings.append(color.to_html(false))
-	_text_edit.text = JSON.stringify(color_strings)
+	%TextEdit.text = JSON.stringify(color_strings)
 
 
 ## Calculate the color strings from our picker rows.
@@ -70,8 +65,8 @@ func _refresh_from_text() -> void:
 	# update picker row colors
 	_refresh_picker_row_colors(parsed_colors)
 	
-	_add_button.disabled = parsed_colors.size() >= 10
-	_remove_button.disabled = parsed_colors.size() <= 1
+	%AddButton.disabled = parsed_colors.size() >= 10
+	%RemoveButton.disabled = parsed_colors.size() <= 1
 	
 	_suppress_listeners = false
 
@@ -84,7 +79,7 @@ func _parse_colors_from_text() -> Array:
 	var parsed_colors := []
 	
 	var test_json_conv := JSON.new()
-	test_json_conv.parse(_text_edit.text)
+	test_json_conv.parse(%TextEdit.text)
 	var result_obj = test_json_conv.get_data()
 	if result_obj is Array:
 		for result_item in result_obj:
@@ -122,7 +117,7 @@ func _refresh_picker_row_colors(new_colors: Array) -> void:
 
 func _add_picker_row() -> void:
 	var new_picker: BackgroundDemoPickerRow = PickerRowScene.instantiate()
-	_picker_container.add_child(new_picker)
+	%PickerContainer.add_child(new_picker)
 	
 	# connect listeners
 	new_picker.go_button_pressed.connect(_on_picker_row_color_picked)
@@ -134,7 +129,7 @@ func _remove_picker_row() -> void:
 	var picker_rows := get_tree().get_nodes_in_group("picker_rows")
 	var picker_row: BackgroundDemoPickerRow = picker_rows.back()
 	picker_row.queue_free()
-	_picker_container.remove_child(picker_row )
+	%PickerContainer.remove_child(picker_row )
 
 
 func _on_picker_row_color_picked(color: Color) -> void:

--- a/project/src/demo/background-demo-picker-row.gd
+++ b/project/src/demo/background-demo-picker-row.gd
@@ -8,19 +8,17 @@ signal shuffle_button_pressed
 
 var color: Color:
 	set(new_color):
-		_color_picker_button.color = new_color
+		%ColorPickerButton.color = new_color
 	get:
-		return _color_picker_button.color
-
-@onready var _color_picker_button := $ColorPickerButton
+		return %ColorPickerButton.color
 
 
 func _on_color_picker_button_popup_closed() -> void:
-	color_picked.emit(_color_picker_button.color)
+	color_picked.emit(%ColorPickerButton.color)
 
 
 func _on_go_button_pressed() -> void:
-	go_button_pressed.emit(_color_picker_button.color)
+	go_button_pressed.emit(%ColorPickerButton.color)
 
 
 func _on_shuffle_button_pressed() -> void:

--- a/project/src/demo/background-demo-preset-tab.gd
+++ b/project/src/demo/background-demo-preset-tab.gd
@@ -7,15 +7,13 @@ const MAX_WORLD_INDEX := 99
 
 @export var background: Background
 
-@onready var _label := $VBoxContainer/HBoxContainer/Label
-
 func _ready() -> void:
 	PlayerData.world_index_changed.connect(_on_player_data_world_index_changed)
 	_refresh_label_text()
 
 
 func _refresh_label_text() -> void:
-	_label.text = "World %s" % [PlayerData.world_index + 1]
+	%WorldLabel.text = "World %s" % [PlayerData.world_index + 1]
 
 
 func _on_world_down_button_pressed() -> void:

--- a/project/src/demo/beach-ball-demo.gd
+++ b/project/src/demo/beach-ball-demo.gd
@@ -11,16 +11,9 @@ extends Node
 
 @export var BeachBallScene: PackedScene
 
-@onready var _panel := $Panel
-
 func _ready() -> void:
 	for _i in range(3):
 		_add_ball()
-
-
-## Preemptively initializes onready variables to avoid null references.
-func _enter_tree() -> void:
-		_panel = $Panel
 
 
 func _input(event: InputEvent) -> void:
@@ -32,7 +25,7 @@ func _input(event: InputEvent) -> void:
 		KEY_3:
 			_bounce_ball(2)
 		KEY_SPACE:
-			for i in range(_panel.get_child_count()):
+			for i in range(%Panel.get_child_count()):
 				_bounce_ball(i)
 		KEY_MINUS:
 			if Input.is_key_pressed(KEY_SHIFT):
@@ -50,27 +43,27 @@ func _input(event: InputEvent) -> void:
 
 func _add_ball() -> void:
 	var ball: BeachBall = BeachBallScene.instantiate()
-	ball.bounce_rect = Rect2(Vector2.ZERO, _panel.size)
+	ball.bounce_rect = Rect2(Vector2.ZERO, %Panel.size)
 	ball.position.x = randf_range(ball.bounce_rect.position.x, ball.bounce_rect.end.x)
 	ball.position.y = randf_range(ball.bounce_rect.position.y, ball.bounce_rect.end.y)
-	_panel.add_child(ball)
+	%Panel.add_child(ball)
 
 
 func _remove_ball() -> void:
-	if _panel.get_child_count() > 0:
-		var ball: BeachBall = _panel.get_child(-1)
+	if %Panel.get_child_count() > 0:
+		var ball: BeachBall = %Panel.get_child(-1)
 		ball.queue_free()
-		_panel.remove_child(ball)
+		%Panel.remove_child(ball)
 
 
 func _bounce_ball(index: int) -> void:
-	if _panel.get_child_count() > index:
-		_panel.get_child(index).bounce()
+	if %Panel.get_child_count() > index:
+		%Panel.get_child(index).bounce()
 
 
 func _refresh_bounce_rect() -> void:
-	for ball in _panel.get_children():
-		ball.bounce_rect = Rect2(Vector2.ZERO, _panel.size)
+	for ball in %Panel.get_children():
+		ball.bounce_rect = Rect2(Vector2.ZERO, %Panel.size)
 
 
 func _on_panel_resized() -> void:

--- a/project/src/demo/comic-letter-demo.gd
+++ b/project/src/demo/comic-letter-demo.gd
@@ -12,10 +12,10 @@ const LETTERS_BY_SCANCODE := {
 	KEY_S:"s", KEY_T:"t", KEY_U:"u", KEY_V:"v", KEY_W:"w", KEY_X:"x", KEY_Y:"y", KEY_Z:"z",
 }
 
-@onready var _current_letter := $Letter1
+@onready var _current_letter := %Letter1
 
 func _ready() -> void:
-	for letter in [$Letter1, $Letter2]:
+	for letter in [%Letter1, %Letter2]:
 		letter.hide_letter()
 		letter.text = Utils.rand_value(["f", "r", "o", "g"])
 		letter.show_letter()
@@ -24,9 +24,9 @@ func _ready() -> void:
 func _input(event: InputEvent) -> void:
 	match Utils.key_scancode(event):
 		KEY_1:
-			_current_letter = $Letter1
+			_current_letter = %Letter1
 		KEY_2:
-			_current_letter = $Letter2
+			_current_letter = %Letter2
 		KEY_SPACE:
 			if _current_letter.visible:
 				_current_letter.hide_letter()

--- a/project/src/demo/comic-page-demo.gd
+++ b/project/src/demo/comic-page-demo.gd
@@ -15,8 +15,6 @@ var _comic_page: ComicPage
 	1: preload("res://src/main/comic/World2ComicPage.tscn"),
 }
 
-@onready var _label := $Label
-
 func _ready() -> void:
 	_set_page(_comic_scenes_by_index[default_comic_index])
 
@@ -48,4 +46,4 @@ func _set_page(comic_scene: PackedScene) -> void:
 	_comic_page.name = "ComicPage"
 	add_child(_comic_page)
 	
-	_label.text = comic_scene.resource_path
+	%ResourcePathLabel.text = comic_scene.resource_path

--- a/project/src/demo/hand-demo.gd
+++ b/project/src/demo/hand-demo.gd
@@ -8,8 +8,6 @@ extends Node
 ## 	[=/-]: Change the number of biteable fingers
 ## 	[brace keys]: Change the number of hugged fingers
 
-@onready var _hand: Hand = $Hand
-
 func _ready() -> void:
 	Input.set_mouse_mode(Input.MOUSE_MODE_HIDDEN)
 
@@ -17,19 +15,19 @@ func _ready() -> void:
 func _input(event: InputEvent) -> void:
 	match Utils.key_scancode(event):
 		KEY_B:
-			_hand.biteable_fingers = 1
-			_hand.bite()
+			%Hand.biteable_fingers = 1
+			%Hand.bite()
 		KEY_R:
-			_hand.ribbon = !_hand.ribbon
+			%Hand.ribbon = !%Hand.ribbon
 		KEY_3:
-			_hand.set_fingers(3)
+			%Hand.set_fingers(3)
 		KEY_MINUS:
-			_hand.biteable_fingers = int(clamp(_hand.biteable_fingers - 1, -1, 3))
+			%Hand.biteable_fingers = int(clamp(%Hand.biteable_fingers - 1, -1, 3))
 		KEY_EQUAL:
-			_hand.biteable_fingers = int(clamp(_hand.biteable_fingers + 1, -1, 3))
+			%Hand.biteable_fingers = int(clamp(%Hand.biteable_fingers + 1, -1, 3))
 		KEY_BRACKETLEFT:
-			_hand.huggable_fingers = 0
-			_hand.hugged_fingers = 0
+			%Hand.huggable_fingers = 0
+			%Hand.hugged_fingers = 0
 		KEY_BRACKETRIGHT:
-			_hand.huggable_fingers = 3
-			_hand.hug()
+			%Hand.huggable_fingers = 3
+			%Hand.hug()

--- a/project/src/demo/intermission-panel-demo.gd
+++ b/project/src/demo/intermission-panel-demo.gd
@@ -12,9 +12,6 @@ extends Node
 ## 	[1..0] -> [W]: Sets the world index.
 ## 	[escape]: Restore the player's hand, so it has all fingers and no ribbon.
 
-@onready var _intermission_panel := $IntermissionPanel
-@onready var _hand := $Hand
-
 ## The most recently pressed number key.
 var number_event: InputEvent
 
@@ -22,8 +19,8 @@ func _ready() -> void:
 	Input.set_mouse_mode(Input.MOUSE_MODE_HIDDEN)
 	PlayerData.music_preference = PlayerData.MusicPreference.OFF
 	
-	_intermission_panel.show_intermission_panel()
-	_intermission_panel.restart("1-1")
+	%IntermissionPanel.show_intermission_panel()
+	%IntermissionPanel.restart("1-1")
 
 
 func _input(event: InputEvent) -> void:
@@ -39,7 +36,7 @@ func _input(event: InputEvent) -> void:
 			card.queue_free()
 			
 			card.show_front()
-			_intermission_panel.add_level_result(card)
+			%IntermissionPanel.add_level_result(card)
 		KEY_H:
 			_start_frog_hug_timer()
 		KEY_M:
@@ -49,19 +46,19 @@ func _input(event: InputEvent) -> void:
 		KEY_R:
 			_start_frog_ribbon()
 		KEY_S:
-			_intermission_panel.start_shark_spawn_timer(3)
+			%IntermissionPanel.start_shark_spawn_timer(3)
 		KEY_T:
-			if _intermission_panel.has_tweak():
-				_intermission_panel.remove_tweak()
+			if %IntermissionPanel.has_tweak():
+				%IntermissionPanel.remove_tweak()
 			else:
-				_intermission_panel.add_tweak()
+				%IntermissionPanel.add_tweak()
 		KEY_W:
 			_assign_world_index()
 		KEY_0, KEY_1, KEY_2, KEY_3, KEY_4, KEY_5, KEY_6, KEY_7, KEY_8, KEY_9:
 			number_event = event
 		KEY_ESCAPE:
-			_hand.reset_fingers()
-			_hand.ribbon = false
+			%Hand.reset_fingers()
+			%Hand.ribbon = false
 
 
 func _start_frog_hug_timer() -> void:
@@ -77,11 +74,11 @@ func _start_frog_hug_timer() -> void:
 		KEY_3, _:
 			frog_count = 3
 			huggable_fingers = 30
-	_intermission_panel.start_frog_hug_timer(frog_count, huggable_fingers)
+	%IntermissionPanel.start_frog_hug_timer(frog_count, huggable_fingers)
 
 
 func _start_frog_dance() -> void:
-	_intermission_panel.reset()
+	%IntermissionPanel.reset()
 	
 	var frog_count: int
 	match Utils.key_scancode(number_event):
@@ -92,13 +89,13 @@ func _start_frog_dance() -> void:
 		_:
 			frog_count = randi_range(1, 10)
 	
-	_intermission_panel.start_frog_dance(frog_count)
+	%IntermissionPanel.start_frog_dance(frog_count)
 
 
 func _start_frog_ribbon() -> void:
-	_intermission_panel.reset()
+	%IntermissionPanel.reset()
 	
-	_intermission_panel.start_frog_ribbon()
+	%IntermissionPanel.start_frog_ribbon()
 
 
 func _assign_world_index() -> void:

--- a/project/src/demo/level-rules-demo.gd
+++ b/project/src/demo/level-rules-demo.gd
@@ -5,14 +5,11 @@ extends Node
 ## 	[space bar]: Generate a new puzzle.
 ## 	[=/-]: Increase/decrease the puzzle difficulty and generate a new puzzle.
 
-@onready var _gameplay_panel := $GameplayPanel
-@onready var _difficulty_label := $DifficultyLabel
-
 @export var LevelRulesScene: PackedScene
 
 func _ready() -> void:
 	randomize()
-	_gameplay_panel.mission_string = "1-1"
+	%GameplayPanel.mission_string = "1-1"
 	_refresh_difficulty_label()
 
 
@@ -21,20 +18,20 @@ func _input(event: InputEvent) -> void:
 		KEY_SPACE:
 			_show_puzzle()
 		KEY_MINUS:
-			_gameplay_panel.player_puzzle_difficulty = int(clamp(_gameplay_panel.player_puzzle_difficulty - 1, 0, 8))
+			%GameplayPanel.player_puzzle_difficulty = int(clamp(%GameplayPanel.player_puzzle_difficulty - 1, 0, 8))
 			_show_puzzle()
 		KEY_EQUAL:
-			_gameplay_panel.player_puzzle_difficulty = int(clamp(_gameplay_panel.player_puzzle_difficulty + 1, 0, 8))
+			%GameplayPanel.player_puzzle_difficulty = int(clamp(%GameplayPanel.player_puzzle_difficulty + 1, 0, 8))
 			_show_puzzle()
 
 
 func _refresh_difficulty_label() -> void:
-	_difficulty_label.text = tr("Difficulty: %s" % [_gameplay_panel.player_puzzle_difficulty])
+	%DifficultyLabel.text = tr("Difficulty: %s" % [%GameplayPanel.player_puzzle_difficulty])
 
 
 func _show_puzzle() -> void:
-	_gameplay_panel.level_ids.assign(["evasive-touch"])
-	_gameplay_panel.level_rules_scenes_by_id = {"evasive-touch": LevelRulesScene}
-	_gameplay_panel.reset()
-	_gameplay_panel.show_puzzle()
+	%GameplayPanel.level_ids.assign(["evasive-touch"])
+	%GameplayPanel.level_rules_scenes_by_id = {"evasive-touch": LevelRulesScene}
+	%GameplayPanel.reset()
+	%GameplayPanel.show_puzzle()
 	_refresh_difficulty_label()


### PR DESCRIPTION
Demos now use Godot 4.x 'unique names'. These utilize a node cache, so we don't need onready variables. They avoid initialization errors where onready variables are temporarily null, so we don't need workarounds such as the workaround in BeachBallDemo.

UniqueNames specifically search for nodes within the same scene. For this reason, I've split out BackgroundDemoCustom and BackgroundDemoPreset into their own scenes to reduce the scope of their unique named nodes.