### PR TITLE
Refactor: WiggleSprite inheritance

### DIFF
--- a/project/src/main/CardControl.tscn
+++ b/project/src/main/CardControl.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=4 format=3 uid="uid://b4gqbolgkyiwd"]
 
 [ext_resource type="AudioStream" uid="uid://dx7kwgym7i72s" path="res://assets/main/sfx/pop-brust.wav" id="1"]
-[ext_resource type="PackedScene" uid="uid://dxaf87rwkxm3n" path="res://src/main/CardSprite.tscn" id="2"]
+[ext_resource type="PackedScene" uid="uid://b2mw4epapu7lq" path="res://src/main/CardSprite.tscn" id="2"]
 [ext_resource type="Script" path="res://src/main/card-control.gd" id="3"]
 
 [node name="CardControl" type="Control" groups=["card_shadow_casters"]]
@@ -11,12 +11,6 @@ anchors_preset = 0
 offset_right = 80.0
 offset_bottom = 80.0
 script = ExtResource("3")
-card_back_type = 3
-card_back_details = ""
-card_front_type = 3
-card_front_details = ""
-practice = false
-shown_face = 0
 
 [node name="CardBack" parent="." instance=ExtResource("2")]
 unique_name_in_owner = true

--- a/project/src/main/CardSprite.tscn
+++ b/project/src/main/CardSprite.tscn
@@ -1,17 +1,11 @@
-[gd_scene load_steps=4 format=3 uid="uid://dxaf87rwkxm3n"]
+[gd_scene load_steps=3 format=3 uid="uid://b2mw4epapu7lq"]
 
-[ext_resource type="Script" path="res://src/main/wiggle-sprite.gd" id="1"]
+[ext_resource type="PackedScene" uid="uid://cbfwawa4bt7lv" path="res://src/main/WiggleSprite.tscn" id="1_m0pg5"]
 [ext_resource type="Texture2D" uid="uid://boi8dc4j74mtc" path="res://assets/main/mystery-sheet.png" id="2"]
-[ext_resource type="PackedScene" uid="uid://brl5be1hh4mw" path="res://src/main/WiggleTimer.tscn" id="3"]
 
-[node name="CardBack" type="Sprite2D"]
+[node name="CardBack" instance=ExtResource("1_m0pg5")]
 position = Vector2(40, 40)
-scale = Vector2(0.333, 0.333)
 texture = ExtResource("2")
 hframes = 8
 vframes = 2
-script = ExtResource("1")
 wiggle_frames = Array[int]([0, 1])
-
-[node name="WiggleTimer" parent="." instance=ExtResource("3")]
-unique_name_in_owner = true

--- a/project/src/main/Hand.tscn
+++ b/project/src/main/Hand.tscn
@@ -3,8 +3,8 @@
 [ext_resource type="Script" path="res://src/main/hand.gd" id="2"]
 [ext_resource type="PackedScene" uid="uid://w0mts35bfghx" path="res://src/main/HandSprite.tscn" id="2_gp3vj"]
 [ext_resource type="PackedScene" uid="uid://b7nexmwrtjune" path="res://src/main/FingerSprite.tscn" id="3"]
-[ext_resource type="PackedScene" uid="uid://d3do0albhfp8k" path="res://src/main/RibbonSprite.tscn" id="4_inyvm"]
-[ext_resource type="PackedScene" uid="uid://8hnpl4vr33mq" path="res://src/main/HugSprite.tscn" id="5_ydavv"]
+[ext_resource type="PackedScene" uid="uid://dcjhye5f2burb" path="res://src/main/RibbonSprite.tscn" id="4_inyvm"]
+[ext_resource type="PackedScene" uid="uid://ccnv0lxmse2ko" path="res://src/main/HugSprite.tscn" id="5_ydavv"]
 
 [node name="Hand" type="Control"]
 layout_mode = 3

--- a/project/src/main/HugSprite.tscn
+++ b/project/src/main/HugSprite.tscn
@@ -1,16 +1,11 @@
-[gd_scene load_steps=4 format=3 uid="uid://8hnpl4vr33mq"]
+[gd_scene load_steps=3 format=3 uid="uid://ccnv0lxmse2ko"]
 
+[ext_resource type="PackedScene" uid="uid://cbfwawa4bt7lv" path="res://src/main/WiggleSprite.tscn" id="1_gm7vj"]
 [ext_resource type="Texture2D" uid="uid://ddu0thu3dp057" path="res://assets/main/hug-sheet.png" id="1_h2nqv"]
-[ext_resource type="Script" path="res://src/main/wiggle-sprite.gd" id="2_q6qq7"]
-[ext_resource type="PackedScene" uid="uid://brl5be1hh4mw" path="res://src/main/WiggleTimer.tscn" id="3_sx8nd"]
 
-[node name="HugSprite" type="Sprite2D"]
+[node name="HugSprite" instance=ExtResource("1_gm7vj")]
 position = Vector2(23, 14)
 scale = Vector2(0.5, 0.5)
 texture = ExtResource("1_h2nqv")
 hframes = 4
 vframes = 2
-script = ExtResource("2_q6qq7")
-
-[node name="WiggleTimer" parent="." instance=ExtResource("3_sx8nd")]
-unique_name_in_owner = true

--- a/project/src/main/RibbonSprite.tscn
+++ b/project/src/main/RibbonSprite.tscn
@@ -1,15 +1,10 @@
-[gd_scene load_steps=4 format=3 uid="uid://d3do0albhfp8k"]
+[gd_scene load_steps=3 format=3 uid="uid://dcjhye5f2burb"]
 
+[ext_resource type="PackedScene" uid="uid://cbfwawa4bt7lv" path="res://src/main/WiggleSprite.tscn" id="1_2p1wf"]
 [ext_resource type="Texture2D" uid="uid://byyt6vk04dwme" path="res://assets/main/hand-ribbon-1-sheet.png" id="1_vunk5"]
-[ext_resource type="Script" path="res://src/main/wiggle-sprite.gd" id="2_tia0f"]
-[ext_resource type="PackedScene" uid="uid://brl5be1hh4mw" path="res://src/main/WiggleTimer.tscn" id="3_rmnw1"]
 
-[node name="RibbonSprite" type="Sprite2D"]
+[node name="RibbonSprite" instance=ExtResource("1_2p1wf")]
 position = Vector2(23, 14)
 scale = Vector2(0.5, 0.5)
 texture = ExtResource("1_vunk5")
 hframes = 3
-script = ExtResource("2_tia0f")
-
-[node name="WiggleTimer" parent="." instance=ExtResource("3_rmnw1")]
-unique_name_in_owner = true


### PR DESCRIPTION
CardSprite, HugSprite and RibbonSprite now extend from WiggleSprite. This encourages code reuse and also makes changes easier, like our recent 'unique name' changes where we needed to modify WiggleTimer's scene properties.