### PR TITLE
LevelRulesDemo errors. Suppressed warnings. FrodokuRules cleanup.

### DIFF
--- a/project/src/demo/LevelRulesDemo.tscn
+++ b/project/src/demo/LevelRulesDemo.tscn
@@ -25,6 +25,7 @@ theme_override_styles/panel = ExtResource("3_qswrx")
 script = ExtResource("1")
 
 [node name="GameState" type="Node" parent="GameplayPanel"]
+unique_name_in_owner = true
 script = ExtResource("2")
 
 [node name="FlipTimer" type="Timer" parent="GameplayPanel/GameState"]
@@ -33,6 +34,7 @@ wait_time = 0.1
 one_shot = true
 
 [node name="LevelCards" type="Control" parent="GameplayPanel" node_paths=PackedStringArray("game_state")]
+unique_name_in_owner = true
 anchors_preset = 0
 anchor_left = 0.5
 anchor_top = 0.5

--- a/project/src/main/levels/frodoku-rules.gd
+++ b/project/src/main/levels/frodoku-rules.gd
@@ -46,6 +46,8 @@ func add_cards() -> void:
 	var revealed_lizard_count := 0
 	var revealed_bad_move_count := 0
 	var hidden_bad_move_count := 0
+	
+	# if 'true', one full row, column or 3x2 region of "bad moves" will be revealed
 	var easy_reveal := false
 	
 	match puzzle_difficulty:
@@ -108,8 +110,8 @@ func add_cards() -> void:
 	var cell_positions := level_cards.get_cell_positions()
 	cell_positions.shuffle()
 	for cell_pos in cell_positions:
-		var row: int = cell_pos.y
-		var col: int = cell_pos.x
+		var row: int = int(cell_pos.y)
+		var col: int = int(cell_pos.x)
 		var region := _region(cell_pos)
 		var card := level_cards.get_card(cell_pos)
 		
@@ -181,7 +183,7 @@ func _hide_bad_moves(count: int) -> void:
 	var cards := level_cards.get_cards()
 	cards.shuffle()
 	for card in cards:
-		if card.is_front_shown() and card.card_front_type == CardControl.CardType.FISH\
+		if card.is_front_shown() and card.card_front_type == CardControl.CardType.FISH \
 				and _conflicting_lizard(card):
 			card.hide_front()
 			remaining -= 1

--- a/project/src/main/levels/froggo-rules.gd
+++ b/project/src/main/levels/froggo-rules.gd
@@ -188,6 +188,7 @@ func add_cards() -> void:
 		var aliax_cell_pos := Vector2(randi_range(0, 2), i)
 		
 		# shift short aliaxes to the right to keep them centered
+		@warning_ignore("integer_division")
 		aliax_cell_pos.x += int(3 - aliaxes[i].length() / 2)
 		
 		_add_aliax(aliaxes[i], aliax_cell_pos)


### PR DESCRIPTION
Enabled unique_name_in_owner flag for LevelRulesDemo's GameState and LevelCards, to allow them to be found by GameplayPanel

Suppressed float precision warnings

Minor FrodokuRules cleanup: whitespace, comments