### PR TITLE
Godot bug workaround for animation playback tracks

### DIFF
--- a/project/src/main/comic/World1ComicPage.tscn
+++ b/project/src/main/comic/World1ComicPage.tscn
@@ -306,7 +306,7 @@ tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
 "clips": PackedStringArray("play", "[stop]"),
-"times": PackedFloat32Array(0, 4)
+"times": PackedFloat32Array(0.001, 4)
 }
 tracks/3/type = "value"
 tracks/3/imported = false
@@ -791,7 +791,7 @@ tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/keys = {
 "clips": PackedStringArray("play", "[stop]"),
-"times": PackedFloat32Array(0, 4)
+"times": PackedFloat32Array(0.001, 4)
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_7nfju"]
@@ -1660,7 +1660,7 @@ tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
 "clips": PackedStringArray("play", "[stop]"),
-"times": PackedFloat32Array(0, 5)
+"times": PackedFloat32Array(0.001, 5)
 }
 tracks/3/type = "value"
 tracks/3/imported = false
@@ -1682,7 +1682,7 @@ tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/keys = {
 "clips": PackedStringArray("play", "[stop]"),
-"times": PackedFloat32Array(0, 5)
+"times": PackedFloat32Array(0.001, 5)
 }
 tracks/5/type = "animation"
 tracks/5/imported = false

--- a/project/src/main/comic/World2ComicPage.tscn
+++ b/project/src/main/comic/World2ComicPage.tscn
@@ -370,7 +370,7 @@ tracks/10/interp = 1
 tracks/10/loop_wrap = true
 tracks/10/keys = {
 "clips": PackedStringArray("play", "[stop]"),
-"times": PackedFloat32Array(0, 5)
+"times": PackedFloat32Array(0.001, 5)
 }
 tracks/11/type = "value"
 tracks/11/imported = false
@@ -807,7 +807,7 @@ tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/keys = {
 "clips": PackedStringArray("play", "[stop]"),
-"times": PackedFloat32Array(0, 4)
+"times": PackedFloat32Array(0.001, 4)
 }
 tracks/9/type = "value"
 tracks/9/imported = false
@@ -1644,7 +1644,7 @@ tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/keys = {
 "clips": PackedStringArray("RESET", "play", "play", "play", "play"),
-"times": PackedFloat32Array(0, 0.875, 1.375, 2.375, 2.875)
+"times": PackedFloat32Array(0.001, 0.875, 1.375, 2.375, 2.875)
 }
 tracks/4/type = "value"
 tracks/4/imported = false


### PR DESCRIPTION
Godot 4.2.2 introduced Godot #91554
(https://github.com/godotengine/godot/issues/91554), a bug with AnimationPlayer
where AnimationPlaybackTrack doesn't call Play properly on the targeted
AnimationPlayer if the track keyframe is set to 0.

A time of 0.001 works.