### PR TITLE
Workaround for 'unique animation library' issue

### DIFF
--- a/project/src/main/comic/ComicPanel.tscn
+++ b/project/src/main/comic/ComicPanel.tscn
@@ -1,68 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://cwmsgbbnkfhuh"]
+[gd_scene load_steps=3 format=3 uid="uid://cwmsgbbnkfhuh"]
 
 [ext_resource type="Script" path="res://src/main/comic/comic-panel.gd" id="1_xt8py"]
-
-[sub_resource type="Animation" id="Animation_iet6j"]
-length = 0.001
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath(".:visible")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath(".:panel_modulate")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Color(1, 1, 1, 1)]
-}
-
-[sub_resource type="Animation" id="Animation_tf33i"]
-resource_name = "play"
-length = 5.0
-step = 0.0625
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath(".:visible")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [true]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath(".:panel_modulate")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.25),
-"transitions": PackedFloat32Array(1, 1),
-"update": 0,
-"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
-}
-
-[sub_resource type="AnimationLibrary" id="AnimationLibrary_tcqoh"]
-_data = {
-"RESET": SubResource("Animation_iet6j"),
-"play": SubResource("Animation_tf33i")
-}
+[ext_resource type="AnimationLibrary" uid="uid://duiovxr4gfg1s" path="res://src/main/comic/default-frame-player-animation-library.tres" id="2_7umws"]
 
 [node name="ComicPanel" type="Control"]
 visible = false
@@ -98,6 +37,7 @@ editor_description = "The node which renders the border of the comic panel."
 position = Vector2(720, 212)
 
 [node name="FramePlayer" type="AnimationPlayer" parent="." groups=["frame_animation_players"]]
+unique_name_in_owner = true
 libraries = {
-"": SubResource("AnimationLibrary_tcqoh")
+"": ExtResource("2_7umws")
 }

--- a/project/src/main/comic/comic-panel.gd
+++ b/project/src/main/comic/comic-panel.gd
@@ -2,6 +2,8 @@
 extends Control
 ## Shows a panel within a comic page.
 
+const DEFAULT_ANIMATION_LIBRARY_PATH := "res://src/main/comic/default-frame-player-animation-library.tres"
+
 ## The modulate property to apply to both the border and inner contents of the comic panel.
 @export var panel_modulate: Color = Color.WHITE:
 	set(new_panel_modulate):
@@ -9,7 +11,31 @@ extends Control
 		_refresh_panel_modulate()
 
 func _ready() -> void:
+	if Engine.is_editor_hint():
+		_ensure_unique_animation_library()
 	_refresh_panel_modulate()
+
+
+## Creates an editable copy of the default parent animation library, if necessary.
+##
+## The parent animation library is read-only, but also includes some useful defaults. This method lets us reuse them
+## while still allowing changes.
+func _ensure_unique_animation_library() -> void:
+	var animation_library: AnimationLibrary = %FramePlayer.get_animation_library("")
+	if animation_library.resource_path != DEFAULT_ANIMATION_LIBRARY_PATH:
+		# animation library is already unique; do not make another copy
+		return
+	
+	if get_tree().edited_scene_root == self:
+		# don't modify the ComicPanel scene itself; only modify descendents
+		return
+	
+	%FramePlayer.remove_animation_library("")
+	%FramePlayer.add_animation_library("", animation_library.duplicate(true))
+	notify_property_list_changed()
+	
+	var relative_path := get_tree().edited_scene_root.get_parent().get_path_to(self)
+	print("Duplicated animation library for editing: %s." % [relative_path])
 
 
 ## Applies our 'panel_modulate' property to the border and inner contents of the comic panel.

--- a/project/src/main/comic/default-frame-player-animation-library.tres
+++ b/project/src/main/comic/default-frame-player-animation-library.tres
@@ -1,0 +1,63 @@
+[gd_resource type="AnimationLibrary" load_steps=3 format=3 uid="uid://duiovxr4gfg1s"]
+
+[sub_resource type="Animation" id="Animation_xkxlu"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:visible")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath(".:panel_modulate")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 1)]
+}
+
+[sub_resource type="Animation" id="Animation_hxuav"]
+resource_name = "play"
+length = 5.0
+step = 0.0625
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:visible")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath(".:panel_modulate")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.25),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+
+[resource]
+_data = {
+"RESET": SubResource("Animation_xkxlu"),
+"play": SubResource("Animation_hxuav")
+}


### PR DESCRIPTION
When creating a new ComicPanel, the animations couldn't be edited because they were reusing the parent AnimationPlayer's AnimationPlayer. I've added some logic to the ComicPanel script so that when a ComicPanel is opened in the editor, it will duplicate the parent animation library. This lets us reuse the parent animations while still allowing changes.