### PR TITLE
ComicPanel.show_all now modifies panel_modulate instead of modulate

### DIFF
--- a/project/src/main/comic/comic-page.gd
+++ b/project/src/main/comic/comic-page.gd
@@ -69,7 +69,7 @@ func show_all() -> void:
 	for child in get_children():
 		if child.name.begins_with("ComicPanel"):
 			child.visible = true
-			child.modulate = Color.WHITE
+			child.panel_modulate = Color.WHITE
 
 
 ## Skips the comic forward or backward.


### PR DESCRIPTION
This prevents an issue where the show_all toggle would leave one or two frames invisible, because their panel_modulate property was transparent.