### PR TITLE
Made 'very small AnimationPlayer numbers' consistent

### DIFF
--- a/project/src/main/comic/World1ComicPage.tscn
+++ b/project/src/main/comic/World1ComicPage.tscn
@@ -2160,7 +2160,7 @@ texture = ExtResource("5_lmw35")
 position = Vector2(285.714, 437.143)
 
 [node name="Students1" type="Sprite2D" parent="ComicPanel01/Contents/FgGroup" index="0"]
-position = Vector2(0, 6.10352e-05)
+position = Vector2(0, 0)
 texture = ExtResource("6_1lxxc")
 
 [node name="Students4" type="Sprite2D" parent="ComicPanel01/Contents/FgGroup" index="1"]

--- a/project/src/main/comic/World2ComicPage.tscn
+++ b/project/src/main/comic/World2ComicPage.tscn
@@ -943,7 +943,7 @@ tracks/10/interp = 1
 tracks/10/loop_wrap = true
 tracks/10/keys = {
 "clips": PackedStringArray("play", "empty"),
-"times": PackedFloat32Array(0.00101563, 4)
+"times": PackedFloat32Array(0.001, 4)
 }
 tracks/11/type = "animation"
 tracks/11/imported = false

--- a/project/src/main/comic/World3ComicPage.tscn
+++ b/project/src/main/comic/World3ComicPage.tscn
@@ -3547,7 +3547,7 @@ tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/keys = {
 "clips": PackedStringArray("play-1", "play-2", "play-3", "[stop]"),
-"times": PackedFloat32Array(7.8125e-05, 2.25, 4.5, 7)
+"times": PackedFloat32Array(0.001, 2.25, 4.5, 7)
 }
 tracks/4/type = "value"
 tracks/4/imported = false


### PR DESCRIPTION
Changed some 'very small AnimationPlayer numbers' to 0.001 instead of using arbitrary values.

Godot #91554 (https://github.com/godotengine/godot/issues/91554) prevents AnimationPlaybackTrack from working with a value of 0, so we use very small numbers. Numbers that are too small (like 0.00001) often cause the same bug, while numbers that are too big (like 0.1) result in visible anomalies, so we've settled on 0.001. Using a consistent number will make it easier to detect and reverse the workaround in Godot 4.3 when the bug is fixed.

Fixed an unusual y coordinate for World1ComicPage.Students1.