### PR TITLE
Delint: Shellcheck violations in orphaned import script

### DIFF
--- a/delint.sh
+++ b/delint.sh
@@ -129,18 +129,18 @@ if [ -n "$FILES" ]; then
   for FILE in $FILES; do
     # check for no file without the .import extension
     if ! [ -f "${FILE%.*}" ]; then
-      RESULT+=(${FILE})
+      RESULT+=("${FILE}")
     fi
   done
 
-  if [ -n "$RESULT" ]; then
+  if [ -n "${RESULT[*]}" ]; then
     echo ""
     echo "Orphaned .import files:"
-    for FILE in ${RESULT[@]}; do
+    for FILE in "${RESULT[@]}"; do
       echo "${FILE}"
     done
     if [ "$CLEAN" ]; then
-      for FILE in ${RESULT[@]}; do
+      for FILE in "${RESULT[@]}"; do
         rm "${FILE}"
       done
       echo "...Orphaned .import files deleted."


### PR DESCRIPTION
Fixed problematic code highlighted by SC2128 (expanding an array without an index only gives the element in the index 0), SC2206 (quote to prevent word splitting/globbing) and SC2068 (double quote array expansions to avoid re-splitting elements)