### PR TITLE
Refactor: Streamline comic fade in, fade out, skip button

### DIFF
--- a/project/src/main/comic/ComicPage.tscn
+++ b/project/src/main/comic/ComicPage.tscn
@@ -1,9 +1,8 @@
-[gd_scene load_steps=11 format=3 uid="uid://dlmim8vsn4mqm"]
+[gd_scene load_steps=10 format=3 uid="uid://dlmim8vsn4mqm"]
 
 [ext_resource type="Script" path="res://src/main/comic/comic-page.gd" id="1_vv4ag"]
 [ext_resource type="Shader" path="res://src/main/comic/scrolling-texture.gdshader" id="2_ddnaq"]
-[ext_resource type="PackedScene" uid="uid://c7k50x3n3ahgf" path="res://src/main/ui/menu/ClickableIcon.tscn" id="36_i2bh0"]
-[ext_resource type="Texture2D" uid="uid://bjadk7hn5xmru" path="res://assets/main/icon-sheet.png" id="37_7jecq"]
+[ext_resource type="PackedScene" uid="uid://bvl1olfsdpsvk" path="res://src/main/comic/ComicSkipButton.tscn" id="3_8scq8"]
 [ext_resource type="Script" path="res://src/main/comic/comic-conductor.gd" id="38_76lyf"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_qo41j"]
@@ -19,42 +18,18 @@ corner_radius_bottom_left = 20
 
 [sub_resource type="Animation" id="Animation_dxbjf"]
 length = 0.001
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("SkipButton:visible")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
 
 [sub_resource type="Animation" id="Animation_3qj25"]
 resource_name = "play"
 length = 28.75
 step = 0.25
-tracks/0/type = "value"
+tracks/0/type = "method"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("SkipButton:visible")
+tracks/0/path = NodePath("SfxPlayer")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 1),
-"transitions": PackedFloat32Array(1, 1),
-"update": 1,
-"values": [false, true]
-}
-tracks/1/type = "method"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("SfxPlayer")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "values": [{
@@ -62,13 +37,13 @@ tracks/1/keys = {
 "method": &"play"
 }]
 }
-tracks/2/type = "method"
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/path = NodePath(".")
-tracks/2/interp = 1
-tracks/2/loop_wrap = true
-tracks/2/keys = {
+tracks/1/type = "method"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath(".")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
 "times": PackedFloat32Array(0, 37.5),
 "transitions": PackedFloat32Array(1, 1),
 "values": [{
@@ -124,7 +99,7 @@ grow_vertical = 2
 expand_mode = 1
 stretch_mode = 1
 
-[node name="SkipButton" parent="." instance=ExtResource("36_i2bh0")]
+[node name="SkipButton" parent="." instance=ExtResource("3_8scq8")]
 visible = false
 layout_mode = 1
 anchors_preset = 3
@@ -138,8 +113,6 @@ offset_right = -20.0
 offset_bottom = -20.0
 grow_horizontal = 0
 grow_vertical = 0
-icon_texture = ExtResource("37_7jecq")
-icon_index = 5
 
 [node name="Conductor" type="AnimationPlayer" parent="." node_paths=PackedStringArray("sfx_player")]
 unique_name_in_owner = true

--- a/project/src/main/comic/ComicSkipButton.tscn
+++ b/project/src/main/comic/ComicSkipButton.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=4 format=3 uid="uid://bvl1olfsdpsvk"]
+
+[ext_resource type="PackedScene" uid="uid://c7k50x3n3ahgf" path="res://src/main/ui/menu/ClickableIcon.tscn" id="1_gmkow"]
+[ext_resource type="Script" path="res://src/main/comic/comic-skip-button.gd" id="2_osuog"]
+[ext_resource type="Texture2D" uid="uid://bjadk7hn5xmru" path="res://assets/main/icon-sheet.png" id="3_w6wlk"]
+
+[node name="SkipButton" instance=ExtResource("1_gmkow")]
+size_flags_horizontal = 8
+size_flags_vertical = 8
+script = ExtResource("2_osuog")
+icon_texture = ExtResource("3_w6wlk")
+icon_index = 5
+
+[node name="ShowTimer" type="Timer" parent="." index="1"]
+unique_name_in_owner = true
+one_shot = true
+
+[connection signal="timeout" from="ShowTimer" to="." method="_on_timer_timeout"]

--- a/project/src/main/comic/World1ComicPage.tscn
+++ b/project/src/main/comic/World1ComicPage.tscn
@@ -1979,42 +1979,18 @@ _data = {
 
 [sub_resource type="Animation" id="Animation_dxbjf"]
 length = 0.001
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("SkipButton:visible")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
 
 [sub_resource type="Animation" id="Animation_3qj25"]
 resource_name = "play"
 length = 28.75
 step = 0.25
-tracks/0/type = "value"
+tracks/0/type = "method"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("SkipButton:visible")
+tracks/0/path = NodePath("SfxPlayer")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 1),
-"transitions": PackedFloat32Array(1, 1),
-"update": 1,
-"values": [false, true]
-}
-tracks/1/type = "method"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("SfxPlayer")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "values": [{
@@ -2022,100 +1998,83 @@ tracks/1/keys = {
 "method": &"play"
 }]
 }
-tracks/2/type = "method"
+tracks/1/type = "animation"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("ComicPanel01/FramePlayer")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"clips": PackedStringArray("RESET", "play"),
+"times": PackedFloat32Array(0, 0.25)
+}
+tracks/2/type = "animation"
 tracks/2/imported = false
 tracks/2/enabled = true
-tracks/2/path = NodePath(".")
+tracks/2/path = NodePath("ComicPanel02/FramePlayer")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
-"times": PackedFloat32Array(0, 28.75),
-"transitions": PackedFloat32Array(1, 1),
-"values": [{
-"args": [],
-"method": &"fade_in"
-}, {
-"args": [],
-"method": &"fade_out"
-}]
+"clips": PackedStringArray("play"),
+"times": PackedFloat32Array(4.75)
 }
 tracks/3/type = "animation"
 tracks/3/imported = false
 tracks/3/enabled = true
-tracks/3/path = NodePath("ComicPanel01/FramePlayer")
+tracks/3/path = NodePath("ComicPanel03/FramePlayer")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/keys = {
-"clips": PackedStringArray("RESET", "play"),
-"times": PackedFloat32Array(0, 0.25)
+"clips": PackedStringArray("play"),
+"times": PackedFloat32Array(8.25)
 }
 tracks/4/type = "animation"
 tracks/4/imported = false
 tracks/4/enabled = true
-tracks/4/path = NodePath("ComicPanel02/FramePlayer")
+tracks/4/path = NodePath("ComicPanel04/FramePlayer")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/keys = {
 "clips": PackedStringArray("play"),
-"times": PackedFloat32Array(4.75)
+"times": PackedFloat32Array(11.75)
 }
 tracks/5/type = "animation"
 tracks/5/imported = false
 tracks/5/enabled = true
-tracks/5/path = NodePath("ComicPanel03/FramePlayer")
+tracks/5/path = NodePath("ComicPanel05/FramePlayer")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/keys = {
 "clips": PackedStringArray("play"),
-"times": PackedFloat32Array(8.25)
+"times": PackedFloat32Array(14.75)
 }
 tracks/6/type = "animation"
 tracks/6/imported = false
 tracks/6/enabled = true
-tracks/6/path = NodePath("ComicPanel04/FramePlayer")
+tracks/6/path = NodePath("ComicPanel06/FramePlayer")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/keys = {
 "clips": PackedStringArray("play"),
-"times": PackedFloat32Array(11.75)
+"times": PackedFloat32Array(18.25)
 }
 tracks/7/type = "animation"
 tracks/7/imported = false
 tracks/7/enabled = true
-tracks/7/path = NodePath("ComicPanel05/FramePlayer")
+tracks/7/path = NodePath("ComicPanel07/FramePlayer")
 tracks/7/interp = 1
 tracks/7/loop_wrap = true
 tracks/7/keys = {
 "clips": PackedStringArray("play"),
-"times": PackedFloat32Array(14.75)
+"times": PackedFloat32Array(20.25)
 }
 tracks/8/type = "animation"
 tracks/8/imported = false
 tracks/8/enabled = true
-tracks/8/path = NodePath("ComicPanel06/FramePlayer")
+tracks/8/path = NodePath("ComicPanel08/FramePlayer")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/keys = {
-"clips": PackedStringArray("play"),
-"times": PackedFloat32Array(18.25)
-}
-tracks/9/type = "animation"
-tracks/9/imported = false
-tracks/9/enabled = true
-tracks/9/path = NodePath("ComicPanel07/FramePlayer")
-tracks/9/interp = 1
-tracks/9/loop_wrap = true
-tracks/9/keys = {
-"clips": PackedStringArray("play"),
-"times": PackedFloat32Array(20.25)
-}
-tracks/10/type = "animation"
-tracks/10/imported = false
-tracks/10/enabled = true
-tracks/10/path = NodePath("ComicPanel08/FramePlayer")
-tracks/10/interp = 1
-tracks/10/loop_wrap = true
-tracks/10/keys = {
 "clips": PackedStringArray("play"),
 "times": PackedFloat32Array(23.75)
 }
@@ -2132,7 +2091,10 @@ _data = {
 material = SubResource("ShaderMaterial_qo41j")
 texture = ExtResource("3_pyu0a")
 
-[node name="ComicPanel01" parent="." index="1" instance=ExtResource("2_kueuy")]
+[node name="SkipButton" parent="." index="1"]
+unique_name_in_owner = true
+
+[node name="ComicPanel01" parent="." index="2" instance=ExtResource("2_kueuy")]
 layout_mode = 1
 offset_left = -336.0
 offset_top = -236.0
@@ -2160,7 +2122,6 @@ texture = ExtResource("5_lmw35")
 position = Vector2(285.714, 437.143)
 
 [node name="Students1" type="Sprite2D" parent="ComicPanel01/Contents/FgGroup" index="0"]
-position = Vector2(0, 0)
 texture = ExtResource("6_1lxxc")
 
 [node name="Students4" type="Sprite2D" parent="ComicPanel01/Contents/FgGroup" index="1"]
@@ -2191,7 +2152,7 @@ libraries = {
 "": SubResource("AnimationLibrary_tcqoh")
 }
 
-[node name="ComicPanel02" parent="." index="2" instance=ExtResource("2_kueuy")]
+[node name="ComicPanel02" parent="." index="3" instance=ExtResource("2_kueuy")]
 layout_mode = 1
 offset_left = 182.0
 offset_top = -235.0
@@ -2316,7 +2277,7 @@ libraries = {
 "": SubResource("AnimationLibrary_u3u61")
 }
 
-[node name="ComicPanel03" parent="." index="3" instance=ExtResource("2_kueuy")]
+[node name="ComicPanel03" parent="." index="4" instance=ExtResource("2_kueuy")]
 layout_mode = 1
 offset_left = -335.0
 offset_top = -75.0
@@ -2350,7 +2311,7 @@ libraries = {
 "": SubResource("AnimationLibrary_6lqbq")
 }
 
-[node name="ComicPanel04" parent="." index="4" instance=ExtResource("2_kueuy")]
+[node name="ComicPanel04" parent="." index="5" instance=ExtResource("2_kueuy")]
 layout_mode = 1
 offset_left = 9.0
 offset_top = -75.0
@@ -2421,7 +2382,7 @@ libraries = {
 "": SubResource("AnimationLibrary_t87uh")
 }
 
-[node name="ComicPanel05" parent="." index="5" instance=ExtResource("2_kueuy")]
+[node name="ComicPanel05" parent="." index="6" instance=ExtResource("2_kueuy")]
 layout_mode = 1
 offset_left = 182.0
 offset_top = -75.0
@@ -2538,7 +2499,7 @@ libraries = {
 "": SubResource("AnimationLibrary_7nfju")
 }
 
-[node name="ComicPanel06" parent="." index="6" instance=ExtResource("2_kueuy")]
+[node name="ComicPanel06" parent="." index="7" instance=ExtResource("2_kueuy")]
 layout_mode = 1
 offset_left = -335.0
 offset_top = 91.0
@@ -2651,7 +2612,7 @@ libraries = {
 "": SubResource("AnimationLibrary_hcrf2")
 }
 
-[node name="ComicPanel07" parent="." index="7" instance=ExtResource("2_kueuy")]
+[node name="ComicPanel07" parent="." index="8" instance=ExtResource("2_kueuy")]
 layout_mode = 1
 offset_left = -162.0
 offset_top = 91.0
@@ -2786,7 +2747,7 @@ libraries = {
 "": SubResource("AnimationLibrary_yhoh5")
 }
 
-[node name="ComicPanel08" parent="." index="8" instance=ExtResource("2_kueuy")]
+[node name="ComicPanel08" parent="." index="9" instance=ExtResource("2_kueuy")]
 layout_mode = 1
 offset_left = 8.0
 offset_top = 91.0

--- a/project/src/main/comic/World2ComicPage.tscn
+++ b/project/src/main/comic/World2ComicPage.tscn
@@ -2997,164 +2997,123 @@ _data = {
 
 [sub_resource type="Animation" id="Animation_dxbjf"]
 length = 0.001
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("SkipButton:visible")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
 
 [sub_resource type="Animation" id="Animation_3qj25"]
 resource_name = "play"
 length = 37.5
 step = 0.25
-tracks/0/type = "value"
+tracks/0/type = "animation"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("SkipButton:visible")
+tracks/0/path = NodePath("ComicPanel01/FramePlayer")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 1),
-"transitions": PackedFloat32Array(1, 1),
-"update": 1,
-"values": [false, true]
+"clips": PackedStringArray("RESET", "play"),
+"times": PackedFloat32Array(0, 0.25)
 }
 tracks/1/type = "animation"
 tracks/1/imported = false
 tracks/1/enabled = true
-tracks/1/path = NodePath("ComicPanel01/FramePlayer")
+tracks/1/path = NodePath("ComicPanel02/FramePlayer")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
-"clips": PackedStringArray("RESET", "play"),
-"times": PackedFloat32Array(0, 0.25)
+"clips": PackedStringArray("play"),
+"times": PackedFloat32Array(4.75)
 }
 tracks/2/type = "animation"
 tracks/2/imported = false
 tracks/2/enabled = true
-tracks/2/path = NodePath("ComicPanel02/FramePlayer")
+tracks/2/path = NodePath("ComicPanel03/FramePlayer")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
 "clips": PackedStringArray("play"),
-"times": PackedFloat32Array(4.75)
+"times": PackedFloat32Array(8.25)
 }
 tracks/3/type = "animation"
 tracks/3/imported = false
 tracks/3/enabled = true
-tracks/3/path = NodePath("ComicPanel03/FramePlayer")
+tracks/3/path = NodePath("ComicPanel04/FramePlayer")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/keys = {
 "clips": PackedStringArray("play"),
-"times": PackedFloat32Array(8.25)
+"times": PackedFloat32Array(11.75)
 }
 tracks/4/type = "animation"
 tracks/4/imported = false
 tracks/4/enabled = true
-tracks/4/path = NodePath("ComicPanel04/FramePlayer")
+tracks/4/path = NodePath("ComicPanel05/FramePlayer")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/keys = {
 "clips": PackedStringArray("play"),
-"times": PackedFloat32Array(11.75)
+"times": PackedFloat32Array(15.25)
 }
 tracks/5/type = "animation"
 tracks/5/imported = false
 tracks/5/enabled = true
-tracks/5/path = NodePath("ComicPanel05/FramePlayer")
+tracks/5/path = NodePath("ComicPanel06/FramePlayer")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/keys = {
 "clips": PackedStringArray("play"),
-"times": PackedFloat32Array(15.25)
+"times": PackedFloat32Array(18.75)
 }
 tracks/6/type = "animation"
 tracks/6/imported = false
 tracks/6/enabled = true
-tracks/6/path = NodePath("ComicPanel06/FramePlayer")
+tracks/6/path = NodePath("ComicPanel07/FramePlayer")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/keys = {
 "clips": PackedStringArray("play"),
-"times": PackedFloat32Array(18.75)
+"times": PackedFloat32Array(22.25)
 }
 tracks/7/type = "animation"
 tracks/7/imported = false
 tracks/7/enabled = true
-tracks/7/path = NodePath("ComicPanel07/FramePlayer")
+tracks/7/path = NodePath("ComicPanel08/FramePlayer")
 tracks/7/interp = 1
 tracks/7/loop_wrap = true
 tracks/7/keys = {
 "clips": PackedStringArray("play"),
-"times": PackedFloat32Array(22.25)
+"times": PackedFloat32Array(25.75)
 }
 tracks/8/type = "animation"
 tracks/8/imported = false
 tracks/8/enabled = true
-tracks/8/path = NodePath("ComicPanel08/FramePlayer")
+tracks/8/path = NodePath("ComicPanel09/FramePlayer")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/keys = {
 "clips": PackedStringArray("play"),
-"times": PackedFloat32Array(25.75)
+"times": PackedFloat32Array(29.25)
 }
 tracks/9/type = "animation"
 tracks/9/imported = false
 tracks/9/enabled = true
-tracks/9/path = NodePath("ComicPanel09/FramePlayer")
+tracks/9/path = NodePath("ComicPanel10/FramePlayer")
 tracks/9/interp = 1
 tracks/9/loop_wrap = true
 tracks/9/keys = {
 "clips": PackedStringArray("play"),
-"times": PackedFloat32Array(29.25)
+"times": PackedFloat32Array(32.75)
 }
-tracks/10/type = "animation"
+tracks/10/type = "method"
 tracks/10/imported = false
 tracks/10/enabled = true
-tracks/10/path = NodePath("ComicPanel10/FramePlayer")
+tracks/10/path = NodePath("SfxPlayer")
 tracks/10/interp = 1
 tracks/10/loop_wrap = true
 tracks/10/keys = {
-"clips": PackedStringArray("play"),
-"times": PackedFloat32Array(32.75)
-}
-tracks/11/type = "method"
-tracks/11/imported = false
-tracks/11/enabled = true
-tracks/11/path = NodePath("SfxPlayer")
-tracks/11/interp = 1
-tracks/11/loop_wrap = true
-tracks/11/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "values": [{
 "args": [0.872],
 "method": &"play"
-}]
-}
-tracks/12/type = "method"
-tracks/12/imported = false
-tracks/12/enabled = true
-tracks/12/path = NodePath(".")
-tracks/12/interp = 1
-tracks/12/loop_wrap = true
-tracks/12/keys = {
-"times": PackedFloat32Array(0, 37.5),
-"transitions": PackedFloat32Array(1, 1),
-"values": [{
-"args": [],
-"method": &"fade_in"
-}, {
-"args": [],
-"method": &"fade_out"
 }]
 }
 
@@ -3173,6 +3132,9 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_6up80")
 [node name="Texture" parent="Bg" index="0"]
 material = SubResource("ShaderMaterial_qo41j")
 texture = ExtResource("3_3n265")
+
+[node name="SkipButton" parent="." index="1"]
+unique_name_in_owner = true
 
 [node name="ComicPanel01" parent="." index="2" instance=ExtResource("4_ynhcm")]
 layout_mode = 1
@@ -3689,7 +3651,7 @@ vframes = 2
 
 [node name="LettersFn" type="Sprite2D" parent="ComicPanel10/Contents" index="8"]
 visible = false
-position = Vector2(275, 75)
+position = Vector2(275, 65.0017)
 texture = ExtResource("53_wtttd")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="ComicPanel10/Contents/LettersFn" index="0"]

--- a/project/src/main/comic/World3ComicPage.tscn
+++ b/project/src/main/comic/World3ComicPage.tscn
@@ -490,24 +490,6 @@ _data = {
 "play": SubResource("Animation_ee4gp")
 }
 
-[sub_resource type="Animation" id="Animation_nw7yi"]
-resource_name = "play"
-length = 2.0001
-loop_mode = 1
-step = 1.0
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath(".:position")
-tracks/0/interp = 2
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 1, 2),
-"transitions": PackedFloat32Array(1, 1, 1),
-"update": 0,
-"values": [Vector2(122.643, 97.0714), Vector2(122.643, 77.071), Vector2(122.643, 97.0714)]
-}
-
 [sub_resource type="Animation" id="Animation_o6uii"]
 length = 0.001
 tracks/0/type = "value"
@@ -526,14 +508,7 @@ tracks/0/keys = {
 [sub_resource type="Animation" id="Animation_mhxgf"]
 resource_name = "empty"
 
-[sub_resource type="AnimationLibrary" id="AnimationLibrary_gruid"]
-_data = {
-"RESET": SubResource("Animation_o6uii"),
-"empty": SubResource("Animation_mhxgf"),
-"play": SubResource("Animation_nw7yi")
-}
-
-[sub_resource type="Animation" id="Animation_h22ah"]
+[sub_resource type="Animation" id="Animation_nw7yi"]
 resource_name = "play"
 length = 2.0001
 loop_mode = 1
@@ -549,6 +524,13 @@ tracks/0/keys = {
 "transitions": PackedFloat32Array(1, 1, 1),
 "update": 0,
 "values": [Vector2(122.643, 97.0714), Vector2(122.643, 77.071), Vector2(122.643, 97.0714)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_gruid"]
+_data = {
+"RESET": SubResource("Animation_o6uii"),
+"empty": SubResource("Animation_mhxgf"),
+"play": SubResource("Animation_nw7yi")
 }
 
 [sub_resource type="Animation" id="Animation_5gqdu"]
@@ -568,6 +550,24 @@ tracks/0/keys = {
 
 [sub_resource type="Animation" id="Animation_8lss0"]
 resource_name = "empty"
+
+[sub_resource type="Animation" id="Animation_h22ah"]
+resource_name = "play"
+length = 2.0001
+loop_mode = 1
+step = 1.0
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:position")
+tracks/0/interp = 2
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 1, 2),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Vector2(122.643, 97.0714), Vector2(122.643, 77.071), Vector2(122.643, 97.0714)]
+}
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_jbjky"]
 _data = {
@@ -1380,7 +1380,7 @@ tracks/4/keys = {
 tracks/5/type = "animation"
 tracks/5/imported = false
 tracks/5/enabled = true
-tracks/5/path = NodePath("../ComicPanel04/Contents/Group/Bongo/AnimationPlayer")
+tracks/5/path = NodePath("Contents/Group/Bongo/AnimationPlayer")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/keys = {
@@ -1574,24 +1574,6 @@ _data = {
 "play": SubResource("Animation_1wn33")
 }
 
-[sub_resource type="Animation" id="Animation_12wbg"]
-resource_name = "play"
-length = 2.0001
-loop_mode = 1
-step = 1.0
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath(".:position")
-tracks/0/interp = 2
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 1, 2),
-"transitions": PackedFloat32Array(1, 1, 1),
-"update": 0,
-"values": [Vector2(648.357, 342.786), Vector2(648.357, 322.786), Vector2(648.357, 342.786)]
-}
-
 [sub_resource type="Animation" id="Animation_xewop"]
 length = 0.001
 tracks/0/type = "value"
@@ -1610,14 +1592,7 @@ tracks/0/keys = {
 [sub_resource type="Animation" id="Animation_lm3e1"]
 resource_name = "empty"
 
-[sub_resource type="AnimationLibrary" id="AnimationLibrary_jx8l0"]
-_data = {
-"RESET": SubResource("Animation_xewop"),
-"empty": SubResource("Animation_lm3e1"),
-"play": SubResource("Animation_12wbg")
-}
-
-[sub_resource type="Animation" id="Animation_lq62f"]
+[sub_resource type="Animation" id="Animation_12wbg"]
 resource_name = "play"
 length = 2.0001
 loop_mode = 1
@@ -1633,6 +1608,13 @@ tracks/0/keys = {
 "transitions": PackedFloat32Array(1, 1, 1),
 "update": 0,
 "values": [Vector2(648.357, 342.786), Vector2(648.357, 322.786), Vector2(648.357, 342.786)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_jx8l0"]
+_data = {
+"RESET": SubResource("Animation_xewop"),
+"empty": SubResource("Animation_lm3e1"),
+"play": SubResource("Animation_12wbg")
 }
 
 [sub_resource type="Animation" id="Animation_p0b7k"]
@@ -1652,6 +1634,24 @@ tracks/0/keys = {
 
 [sub_resource type="Animation" id="Animation_urkc6"]
 resource_name = "empty"
+
+[sub_resource type="Animation" id="Animation_lq62f"]
+resource_name = "play"
+length = 2.0001
+loop_mode = 1
+step = 1.0
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:position")
+tracks/0/interp = 2
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 1, 2),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Vector2(648.357, 342.786), Vector2(648.357, 322.786), Vector2(648.357, 342.786)]
+}
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_gfimc"]
 _data = {
@@ -2106,6 +2106,21 @@ _data = {
 "play": SubResource("Animation_k7xsl")
 }
 
+[sub_resource type="Animation" id="Animation_0a3tp"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:frame")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [0]
+}
+
 [sub_resource type="Animation" id="Animation_x2yiq"]
 resource_name = "play"
 length = 1.83335
@@ -2122,21 +2137,6 @@ tracks/0/keys = {
 "transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
 "update": 1,
 "values": [0, 1, 0, 1, 1, 0, 1, 1, 0, 1, 0, 0]
-}
-
-[sub_resource type="Animation" id="Animation_0a3tp"]
-length = 0.001
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath(".:frame")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [0]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_dlhpd"]
@@ -2765,24 +2765,6 @@ _data = {
 "play": SubResource("Animation_f0y2l")
 }
 
-[sub_resource type="Animation" id="Animation_ja2p2"]
-resource_name = "play"
-length = 2.0001
-loop_mode = 1
-step = 1.0
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath(".:position")
-tracks/0/interp = 2
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 1, 2),
-"transitions": PackedFloat32Array(1, 1, 1),
-"update": 0,
-"values": [Vector2(336.357, 76.4999), Vector2(336.357, 56.5), Vector2(336.357, 76.4999)]
-}
-
 [sub_resource type="Animation" id="Animation_aydrp"]
 length = 0.001
 tracks/0/type = "value"
@@ -2801,14 +2783,7 @@ tracks/0/keys = {
 [sub_resource type="Animation" id="Animation_nbi1y"]
 resource_name = "empty"
 
-[sub_resource type="AnimationLibrary" id="AnimationLibrary_ka3s0"]
-_data = {
-"RESET": SubResource("Animation_aydrp"),
-"empty": SubResource("Animation_nbi1y"),
-"play": SubResource("Animation_ja2p2")
-}
-
-[sub_resource type="Animation" id="Animation_kovts"]
+[sub_resource type="Animation" id="Animation_ja2p2"]
 resource_name = "play"
 length = 2.0001
 loop_mode = 1
@@ -2823,7 +2798,14 @@ tracks/0/keys = {
 "times": PackedFloat32Array(0, 1, 2),
 "transitions": PackedFloat32Array(1, 1, 1),
 "update": 0,
-"values": [Vector2(336.357, 76.5), Vector2(336.357, 56.5), Vector2(336.357, 76.5)]
+"values": [Vector2(336.357, 76.4999), Vector2(336.357, 56.5), Vector2(336.357, 76.4999)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_ka3s0"]
+_data = {
+"RESET": SubResource("Animation_aydrp"),
+"empty": SubResource("Animation_nbi1y"),
+"play": SubResource("Animation_ja2p2")
 }
 
 [sub_resource type="Animation" id="Animation_truav"]
@@ -2843,6 +2825,24 @@ tracks/0/keys = {
 
 [sub_resource type="Animation" id="Animation_ig67b"]
 resource_name = "empty"
+
+[sub_resource type="Animation" id="Animation_kovts"]
+resource_name = "play"
+length = 2.0001
+loop_mode = 1
+step = 1.0
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:position")
+tracks/0/interp = 2
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 1, 2),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Vector2(336.357, 76.5), Vector2(336.357, 56.5), Vector2(336.357, 76.5)]
+}
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_j0sv0"]
 _data = {
@@ -3604,42 +3604,18 @@ _data = {
 
 [sub_resource type="Animation" id="Animation_dxbjf"]
 length = 0.001
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("SkipButton:visible")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
 
 [sub_resource type="Animation" id="Animation_3qj25"]
 resource_name = "play"
 length = 39.0
 step = 0.25
-tracks/0/type = "value"
+tracks/0/type = "method"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("SkipButton:visible")
+tracks/0/path = NodePath("SfxPlayer")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 1),
-"transitions": PackedFloat32Array(1, 1),
-"update": 1,
-"values": [false, true]
-}
-tracks/1/type = "method"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("SfxPlayer")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "values": [{
@@ -3647,110 +3623,93 @@ tracks/1/keys = {
 "method": &"play"
 }]
 }
-tracks/2/type = "method"
+tracks/1/type = "animation"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("ComicPanel01/FramePlayer")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"clips": PackedStringArray("RESET", "play"),
+"times": PackedFloat32Array(0, 0.25)
+}
+tracks/2/type = "animation"
 tracks/2/imported = false
 tracks/2/enabled = true
-tracks/2/path = NodePath(".")
+tracks/2/path = NodePath("ComicPanel02/FramePlayer")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
-"times": PackedFloat32Array(0, 39),
-"transitions": PackedFloat32Array(1, 1),
-"values": [{
-"args": [],
-"method": &"fade_in"
-}, {
-"args": [],
-"method": &"fade_out"
-}]
+"clips": PackedStringArray("play"),
+"times": PackedFloat32Array(4.75)
 }
 tracks/3/type = "animation"
 tracks/3/imported = false
 tracks/3/enabled = true
-tracks/3/path = NodePath("ComicPanel01/FramePlayer")
+tracks/3/path = NodePath("ComicPanel03/FramePlayer")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/keys = {
-"clips": PackedStringArray("RESET", "play"),
-"times": PackedFloat32Array(0, 0.25)
+"clips": PackedStringArray("play"),
+"times": PackedFloat32Array(7.25)
 }
 tracks/4/type = "animation"
 tracks/4/imported = false
 tracks/4/enabled = true
-tracks/4/path = NodePath("ComicPanel02/FramePlayer")
+tracks/4/path = NodePath("ComicPanel04/FramePlayer")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/keys = {
 "clips": PackedStringArray("play"),
-"times": PackedFloat32Array(4.75)
+"times": PackedFloat32Array(10.75)
 }
 tracks/5/type = "animation"
 tracks/5/imported = false
 tracks/5/enabled = true
-tracks/5/path = NodePath("ComicPanel03/FramePlayer")
+tracks/5/path = NodePath("ComicPanel05/FramePlayer")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/keys = {
 "clips": PackedStringArray("play"),
-"times": PackedFloat32Array(7.25)
+"times": PackedFloat32Array(16.25)
 }
 tracks/6/type = "animation"
 tracks/6/imported = false
 tracks/6/enabled = true
-tracks/6/path = NodePath("ComicPanel04/FramePlayer")
+tracks/6/path = NodePath("ComicPanel06/FramePlayer")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/keys = {
 "clips": PackedStringArray("play"),
-"times": PackedFloat32Array(10.75)
+"times": PackedFloat32Array(19.75)
 }
 tracks/7/type = "animation"
 tracks/7/imported = false
 tracks/7/enabled = true
-tracks/7/path = NodePath("ComicPanel05/FramePlayer")
+tracks/7/path = NodePath("ComicPanel07/FramePlayer")
 tracks/7/interp = 1
 tracks/7/loop_wrap = true
 tracks/7/keys = {
 "clips": PackedStringArray("play"),
-"times": PackedFloat32Array(16.25)
+"times": PackedFloat32Array(24)
 }
 tracks/8/type = "animation"
 tracks/8/imported = false
 tracks/8/enabled = true
-tracks/8/path = NodePath("ComicPanel06/FramePlayer")
+tracks/8/path = NodePath("ComicPanel08/FramePlayer")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/keys = {
 "clips": PackedStringArray("play"),
-"times": PackedFloat32Array(19.75)
+"times": PackedFloat32Array(29.5)
 }
 tracks/9/type = "animation"
 tracks/9/imported = false
 tracks/9/enabled = true
-tracks/9/path = NodePath("ComicPanel07/FramePlayer")
+tracks/9/path = NodePath("ComicPanel09/FramePlayer")
 tracks/9/interp = 1
 tracks/9/loop_wrap = true
 tracks/9/keys = {
-"clips": PackedStringArray("play"),
-"times": PackedFloat32Array(24)
-}
-tracks/10/type = "animation"
-tracks/10/imported = false
-tracks/10/enabled = true
-tracks/10/path = NodePath("ComicPanel08/FramePlayer")
-tracks/10/interp = 1
-tracks/10/loop_wrap = true
-tracks/10/keys = {
-"clips": PackedStringArray("play"),
-"times": PackedFloat32Array(29.5)
-}
-tracks/11/type = "animation"
-tracks/11/imported = false
-tracks/11/enabled = true
-tracks/11/path = NodePath("ComicPanel09/FramePlayer")
-tracks/11/interp = 1
-tracks/11/loop_wrap = true
-tracks/11/keys = {
 "clips": PackedStringArray("play"),
 "times": PackedFloat32Array(32)
 }
@@ -3762,7 +3721,6 @@ _data = {
 }
 
 [node name="ComicPage" instance=ExtResource("1_l7rca")]
-visible = true
 
 [node name="Bg" parent="." index="0"]
 material = SubResource("ShaderMaterial_qo41j")
@@ -3771,6 +3729,9 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_6up80")
 [node name="Texture" parent="Bg" index="0"]
 material = SubResource("ShaderMaterial_qo41j")
 texture = ExtResource("3_7g1yb")
+
+[node name="SkipButton" parent="." index="1"]
+unique_name_in_owner = true
 
 [node name="ComicPanel01" parent="." index="2" instance=ExtResource("4_6cv51")]
 layout_mode = 1
@@ -3911,7 +3872,6 @@ libraries = {
 [node name="LettersId" type="Sprite2D" parent="ComicPanel02/Contents" index="4"]
 visible = false
 position = Vector2(122.643, 97.0714)
-scale = Vector2(1, 1)
 texture = ExtResource("19_2jp3p")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="ComicPanel02/Contents/LettersId" index="0"]
@@ -3922,7 +3882,6 @@ libraries = {
 [node name="LettersFn" type="Sprite2D" parent="ComicPanel02/Contents" index="5"]
 visible = false
 position = Vector2(122.643, 97.0714)
-scale = Vector2(1, 1)
 texture = ExtResource("18_akut2")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="ComicPanel02/Contents/LettersFn" index="0"]
@@ -4138,7 +4097,6 @@ libraries = {
 [node name="LettersId" type="Sprite2D" parent="ComicPanel05/Contents" index="5"]
 visible = false
 position = Vector2(648.357, 342.786)
-scale = Vector2(1, 1)
 texture = ExtResource("19_2jp3p")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="ComicPanel05/Contents/LettersId" index="0"]
@@ -4149,7 +4107,6 @@ libraries = {
 [node name="LettersFn" type="Sprite2D" parent="ComicPanel05/Contents" index="6"]
 visible = false
 position = Vector2(648.357, 342.786)
-scale = Vector2(1, 1)
 texture = ExtResource("18_akut2")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="ComicPanel05/Contents/LettersFn" index="0"]
@@ -4391,7 +4348,6 @@ libraries = {
 [node name="LettersId" type="Sprite2D" parent="ComicPanel08/Contents" index="4"]
 visible = false
 position = Vector2(336.357, 76.4999)
-scale = Vector2(1, 1)
 texture = ExtResource("51_5aa10")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="ComicPanel08/Contents/LettersId" index="0"]
@@ -4402,7 +4358,6 @@ libraries = {
 [node name="LettersFn" type="Sprite2D" parent="ComicPanel08/Contents" index="5"]
 visible = false
 position = Vector2(336.357, 76.5)
-scale = Vector2(1, 1)
 texture = ExtResource("52_uh5t8")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="ComicPanel08/Contents/LettersFn" index="0"]

--- a/project/src/main/comic/comic-page.gd
+++ b/project/src/main/comic/comic-page.gd
@@ -34,6 +34,8 @@ var _fade_tween: Tween
 func _ready() -> void:
 	# hide; avoid blocking input
 	visible = false
+	%Conductor.animation_finished.connect(_on_conductor_animation_finished)
+
 
 ## Launches the comic animation.
 ##
@@ -43,6 +45,8 @@ func play() -> void:
 	stop()
 	
 	%Conductor.play("play")
+	fade_in()
+	%SkipButton.hide_briefly()
 
 
 func is_playing() -> bool:
@@ -110,6 +114,11 @@ func fade_out() -> void:
 	_fade_tween = Utils.recreate_tween(self, _fade_tween)
 	_fade_tween.tween_property(self, "modulate", Color.TRANSPARENT, 0.25)
 	_fade_tween.tween_callback(stop)
+
+
+func _on_conductor_animation_finished(animation_name: String) -> void:
+	if animation_name == "play":
+		fade_out()
 
 
 func _on_skip_button_pressed() -> void:

--- a/project/src/main/comic/comic-skip-button.gd
+++ b/project/src/main/comic/comic-skip-button.gd
@@ -1,0 +1,11 @@
+extends ClickableIcon
+## Button which lets the player skip comic animations.
+
+## Temporarily hides the button to prevent the player from skipping the comic too quickly.
+func hide_briefly() -> void:
+	visible = false
+	%ShowTimer.start()
+
+
+func _on_timer_timeout() -> void:
+	visible = true


### PR DESCRIPTION
Comic animations no longer explicitly call fade in, fade out, or control the skip button's visibility. This is handled by ComicPage.tscn, ComicSkipButton.tscn.

Before, all of our comic animations call "fade_out" on the last frame, and it caused a bug we had to fix in #315.