### PR TITLE
Reverted workaround for Godot #91554

### DIFF
--- a/project/src/main/comic/World1ComicPage.tscn
+++ b/project/src/main/comic/World1ComicPage.tscn
@@ -356,7 +356,7 @@ tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
 "clips": PackedStringArray("play", "[stop]"),
-"times": PackedFloat32Array(0.001, 4)
+"times": PackedFloat32Array(0, 4)
 }
 tracks/3/type = "value"
 tracks/3/imported = false
@@ -937,7 +937,7 @@ tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/keys = {
 "clips": PackedStringArray("play", "[stop]"),
-"times": PackedFloat32Array(0.001, 4)
+"times": PackedFloat32Array(0, 4)
 }
 tracks/4/type = "value"
 tracks/4/imported = false
@@ -1902,7 +1902,7 @@ tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
 "clips": PackedStringArray("play", "[stop]"),
-"times": PackedFloat32Array(0.001, 5)
+"times": PackedFloat32Array(0, 5)
 }
 tracks/3/type = "value"
 tracks/3/imported = false
@@ -1924,7 +1924,7 @@ tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/keys = {
 "clips": PackedStringArray("play", "[stop]"),
-"times": PackedFloat32Array(0.001, 5)
+"times": PackedFloat32Array(0, 5)
 }
 tracks/5/type = "animation"
 tracks/5/imported = false

--- a/project/src/main/comic/World2ComicPage.tscn
+++ b/project/src/main/comic/World2ComicPage.tscn
@@ -374,7 +374,7 @@ tracks/10/interp = 1
 tracks/10/loop_wrap = true
 tracks/10/keys = {
 "clips": PackedStringArray("play", "[stop]"),
-"times": PackedFloat32Array(0.001, 5)
+"times": PackedFloat32Array(0, 5)
 }
 tracks/11/type = "value"
 tracks/11/imported = false
@@ -921,7 +921,7 @@ tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/keys = {
 "clips": PackedStringArray("play", "[stop]"),
-"times": PackedFloat32Array(0.001, 4)
+"times": PackedFloat32Array(0, 4)
 }
 tracks/9/type = "value"
 tracks/9/imported = false
@@ -943,7 +943,7 @@ tracks/10/interp = 1
 tracks/10/loop_wrap = true
 tracks/10/keys = {
 "clips": PackedStringArray("play", "empty"),
-"times": PackedFloat32Array(0.001, 4)
+"times": PackedFloat32Array(0, 4)
 }
 tracks/11/type = "animation"
 tracks/11/imported = false
@@ -1680,7 +1680,7 @@ tracks/11/path = NodePath("Contents/Clouds:position")
 tracks/11/interp = 1
 tracks/11/loop_wrap = true
 tracks/11/keys = {
-"times": PackedFloat32Array(0, 4.00001),
+"times": PackedFloat32Array(0, 4),
 "transitions": PackedFloat32Array(1, 1),
 "update": 0,
 "values": [Vector2(191.428, 214.286), Vector2(251.428, 214.286)]
@@ -1956,7 +1956,7 @@ tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/keys = {
 "clips": PackedStringArray("RESET", "play", "play", "play", "play"),
-"times": PackedFloat32Array(0.001, 0.875, 1.375, 2.375, 2.875)
+"times": PackedFloat32Array(0, 0.875, 1.375, 2.375, 2.875)
 }
 tracks/4/type = "value"
 tracks/4/imported = false

--- a/project/src/main/comic/World3ComicPage.tscn
+++ b/project/src/main/comic/World3ComicPage.tscn
@@ -330,7 +330,7 @@ tracks/7/interp = 1
 tracks/7/loop_wrap = true
 tracks/7/keys = {
 "clips": PackedStringArray("play", "[stop]"),
-"times": PackedFloat32Array(0.001, 5)
+"times": PackedFloat32Array(0, 5)
 }
 tracks/8/type = "animation"
 tracks/8/imported = false
@@ -340,7 +340,7 @@ tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/keys = {
 "clips": PackedStringArray("play", "[stop]"),
-"times": PackedFloat32Array(0.001, 5)
+"times": PackedFloat32Array(0, 5)
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_tcqoh"]
@@ -1375,7 +1375,7 @@ tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/keys = {
 "clips": PackedStringArray("play", "[stop]"),
-"times": PackedFloat32Array(0.001, 6)
+"times": PackedFloat32Array(0, 6)
 }
 tracks/5/type = "animation"
 tracks/5/imported = false
@@ -1385,7 +1385,7 @@ tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/keys = {
 "clips": PackedStringArray("play", "[stop]"),
-"times": PackedFloat32Array(0.001, 6)
+"times": PackedFloat32Array(0, 6)
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_hgyf4"]
@@ -2266,7 +2266,7 @@ tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/keys = {
 "clips": PackedStringArray("play", "[stop]"),
-"times": PackedFloat32Array(0.001, 5)
+"times": PackedFloat32Array(0, 5)
 }
 tracks/4/type = "value"
 tracks/4/imported = false
@@ -2319,7 +2319,7 @@ tracks/8/path = NodePath("Contents/Group:position")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/keys = {
-"times": PackedFloat32Array(0, 2.5, 3.5, 4.5, 5.00002),
+"times": PackedFloat32Array(0, 2.5, 3.5, 4.5, 5),
 "transitions": PackedFloat32Array(1, 1.5, 0.666667, 1, 1),
 "update": 0,
 "values": [Vector2(0, 0), Vector2(0, 0), Vector2(48.5714, 0), Vector2(97.1428, 0), Vector2(97.1428, 0)]
@@ -2554,7 +2554,7 @@ tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/keys = {
 "clips": PackedStringArray("play", "[stop]"),
-"times": PackedFloat32Array(0.001, 6)
+"times": PackedFloat32Array(0, 6)
 }
 tracks/5/type = "animation"
 tracks/5/imported = false
@@ -3032,7 +3032,7 @@ tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/keys = {
 "clips": PackedStringArray("play", "[stop]"),
-"times": PackedFloat32Array(0.001, 3)
+"times": PackedFloat32Array(0, 3)
 }
 tracks/5/type = "value"
 tracks/5/imported = false
@@ -3537,7 +3537,7 @@ tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
 "clips": PackedStringArray("play", "[stop]"),
-"times": PackedFloat32Array(0.001, 7)
+"times": PackedFloat32Array(0, 7)
 }
 tracks/3/type = "animation"
 tracks/3/imported = false
@@ -3547,7 +3547,7 @@ tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/keys = {
 "clips": PackedStringArray("play-1", "play-2", "play-3", "[stop]"),
-"times": PackedFloat32Array(0.001, 2.25, 4.5, 7)
+"times": PackedFloat32Array(0, 2.25, 4.5, 7)
 }
 tracks/4/type = "value"
 tracks/4/imported = false


### PR DESCRIPTION
https://github.com/godotengine/godot/issues/91554

Godot #91554 resulted in animations breaking if we called an AnimationPlayer at a time of 0, and required a time of 0.001. I've rolled back this workaround.